### PR TITLE
Update pyyaml and docker-compose versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requires = [
     'future>=0.16.0,<0.17.0',
     'pathspec==0.5.9',
     'python-dateutil>=2.1,<2.8.1',  # use the same range that 'botocore' uses
-    'PyYAML>=3.10,<=3.13',  # use the same range that 'aws-cli' uses. This is also compatible with 'docker-compose'
+    'PyYAML>=5.3, <5.4',  # use the same range that 'aws-cli' uses. This is also compatible with 'docker-compose'
     'requests>=2.20.1,<2.21',
     'setuptools >= 20.0',
     'semantic_version == 2.5.0',
@@ -49,7 +49,7 @@ extras_require = {
 
 }
 if not sys.platform.startswith('win'):
-    requires.append('docker-compose >= 1.23.2, < 1.24.0')
+    requires.append('docker-compose >= 1.25.2, < 1.26.0')
     requires.append('blessed>=1.9.5')
 
 


### PR DESCRIPTION
*Description of changes:*
Updating docker-compose so that the ebcli can update it's version of pyyaml.

Pyyaml in version 4.x has a few security vulnerabilities, currently no versions of 4 are supported on the ebcli so we are skipping 4 and going straight to 5.x. This comes with the update of docker-compose that has recently added support for a similar range in pyyaml.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
