### PR TITLE
Release/3.17.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 -------------------
+3.17.1 (2020-01-22)
+-------------------
+- Updated botocore requirement to `>=1.14.0,<1.15`
+- Updated PyYAML requirement to `>=5.2, <5.3`
+- Updated docker-compose requirement to `>=1.15.2,<1.26.0`
+
+-------------------
 3.17.0 (2019-12-20)
 -------------------
 - Added `--on-demand-base-capacity` and `--on-demand-above-base-capacity` arguments to the `eb create` command

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 -------------------
 - Updated botocore requirement to `>=1.14.0,<1.15`
 - Updated PyYAML requirement to `>=5.2, <5.3`
-- Updated docker-compose requirement to `>=1.15.2,<1.26.0`
+- Updated docker-compose requirement to `>=1.25.2,<1.26.0`
 
 -------------------
 3.17.0 (2019-12-20)

--- a/ebcli/__init__.py
+++ b/ebcli/__init__.py
@@ -11,4 +11,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-__version__ = '3.17.0'
+__version__ = '3.17.1'


### PR DESCRIPTION
Releasing 3.17.1

-------------------
3.17.1 (2020-01-22)
-------------------
- Updated botocore requirement to `>=1.14.0,<1.15`
- Updated PyYAML requirement to `>=5.2, <5.3`
- Updated docker-compose requirement to `>=1.25.2,<1.26.0`