### PR TITLE
Use a set for the .ebignore list

### DIFF
--- a/ebcli/core/fileoperations.py
+++ b/ebcli/core/fileoperations.py
@@ -425,8 +425,8 @@ def zip_up_project(location, ignore_list=None):
 
 def _zipdir(path, zipf, ignore_list=None):
     if ignore_list is None:
-        ignore_list = ['.gitignore']
-    ignore_list = ['./' + i for i in ignore_list]
+        ignore_list = {'.gitignore'}
+    ignore_list = {'./' + i for i in ignore_list}
     zipped_roots = []
     for root, dirs, files in os.walk(path):
         if '.elasticbeanstalk' in root:
@@ -796,8 +796,8 @@ def get_ebignore_list():
     with codecs.open(location, 'r', encoding='utf-8') as f:
         spec = PathSpec.from_lines('gitwildmatch', f)
 
-    ignore_list = [f for f in spec.match_tree(get_project_root())]
-    ignore_list.append('.ebignore')
+    ignore_list = {f for f in spec.match_tree(get_project_root())}
+    ignore_list.add('.ebignore')
 
     return ignore_list
 

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -1757,7 +1757,7 @@ class TestCommonOperations(unittest.TestCase):
         get_zip_location_mock.return_value = 'file_path'
         file_exists_mock.return_value = False
         source_control_mock = mock.MagicMock()
-        get_ebignore_list_mock.return_value = ['index.html']
+        get_ebignore_list_mock.return_value = {'index.html'}
 
         self.assertEqual(
             ('version-label.zip', 'file_path'),
@@ -1767,7 +1767,7 @@ class TestCommonOperations(unittest.TestCase):
             )
         )
 
-        zip_up_project_mock.assert_called_once_with('file_path', ignore_list=['index.html'])
+        zip_up_project_mock.assert_called_once_with('file_path', ignore_list={'index.html'})
 
     @mock.patch('ebcli.operations.commonops.elasticbeanstalk.update_environment')
     @mock.patch('ebcli.operations.commonops.wait_for_success_events')

--- a/tests/unit/operations/test_ebignore.py
+++ b/tests/unit/operations/test_ebignore.py
@@ -71,7 +71,7 @@ directory_1/.dotted_file
                 'directory_1{}.dotted_file'.format(os.path.sep),
                 '.ebignore'
             },
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @patch('ebcli.core.fileoperations.get_project_root')
@@ -105,7 +105,7 @@ directory_1/file_2
 
         self.assertEqual(
             {'file_1', 'directory_1{}file_2'.format(os.path.sep), '.ebignore'},
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @patch('ebcli.core.fileoperations.get_project_root')
@@ -143,7 +143,7 @@ directory_2/
                 'directory_2{}.gitkeep'.format(os.path.sep),
                 '.ebignore'
             },
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @patch('ebcli.core.fileoperations.get_project_root')
@@ -190,7 +190,7 @@ directory_1/directory_2/*
                 'directory_1{0}directory_2{0}file_1'.format(os.path.sep),
                 '.ebignore'
             },
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @patch('ebcli.core.fileoperations.get_project_root')
@@ -217,7 +217,7 @@ file\ 1
 
         self.assertEqual(
             {'file 1', '.ebignore'},
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @patch('ebcli.core.fileoperations.get_project_root')
@@ -245,7 +245,7 @@ file\ 1
 
         self.assertEqual(
             {'!file_1', '.ebignore'},
-            set(paths_to_ignore)
+            paths_to_ignore
         )
 
     @unittest.skipIf(sys.version_info < (3, 0), reason='Python 2.7.x does not support non-ASCII characters')
@@ -278,5 +278,5 @@ file\ 1
 
         self.assertEqual(
             {'哈哈', '昨夜のコンサートは最高でした。', 'ändrar något i databasen', '.ebignore'},
-            set(paths_to_ignore)
+            paths_to_ignore
         )


### PR DESCRIPTION
I've made a small change to the .ebignore implementation to use a set instead of a list.

The ignore list is only used when creating an application version and zipping up the project. For each and every file in the project, the current implementation iterates over the ignore list looking for a match.

Using a set instead cuts the time required to create application versions in my project from ~46 seconds down to ~6 seconds.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
