### PR TITLE
Fix colorama version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import ebcli
 requires = [
     'botocore>=1.14.0,<1.15',
     'cement==2.8.2',
-    'colorama>=0.3.9,<0.4.0',  # use the same range that 'docker-compose' uses
+    'colorama>=0.4,<1.0',  # use the same range that 'docker-compose' uses
     'future>=0.16.0,<0.17.0',
     'pathspec==0.5.9',
     'python-dateutil>=2.1,<2.8.1',  # use the same range that 'botocore' uses


### PR DESCRIPTION
Could you fix this problem?
```bash
$ poetry add awsebcli
Using version ^3.17.1 for awsebcli

Updating dependencies
Resolving dependencies... (0.3s)

[SolverProblemError]
Because no versions of docker-compose match >1.25.2,<1.25.3 || >1.25.3,<1.25.4 || >1.25.4,<1.26.0
 and docker-compose (1.25.2) depends on colorama (>=0.4,<1), docker-compose (>=1.25.2,<1.25.3 || >1.25.3,<1.25.4 || >1.25.4,<1.26.0) requires colorama (>=0.4,<1).
And because docker-compose (1.25.3) depends on colorama (>=0.4,<1)
 and docker-compose (1.25.4) depends on colorama (>=0.4,<1), docker-compose (>=1.25.2,<1.26.0) requires colorama (>=0.4,<1).
And because awsebcli (3.17.1) depends on both colorama (>=0.3.9,<0.4.0) and docker-compose (>=1.25.2,<1.26.0), awsebcli is forbidden.
So, because no versions of awsebcli match >3.17.1,<4.0.0
 and deployapp depends on awsebcli (^3.17.1), version solving failed.
```