### PR TITLE
Fix colorama dependency version so we can install awsebcli with Poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import ebcli
 requires = [
     'botocore>=1.14.0,<1.15',
     'cement==2.8.2',
-    'colorama>=0.3.9,<0.4.0',  # use the same range that 'docker-compose' uses
+    'colorama>0.3.9,<=0.4.0',  # use the same range that 'docker-compose' uses
     'future>=0.16.0,<0.17.0',
     'pathspec==0.5.9',
     'python-dateutil>=2.1,<2.8.1',  # use the same range that 'botocore' uses


### PR DESCRIPTION
*Issue #, if available:*

Fixes #23 

*Description of changes:*

This is a quick fix, duct tape really.

I edited the colorama dependency so it wouldn't conflict with docker's.

Now Poetry can resolve its recursive dependencies and it installs:
```
$ poetry add git+https://github.com/candeira/aws-elastic-beanstalk-cli.git@2742338
(....)
$ poetry run eb
usage: eb (sub-commands ...) [options ...] {arguments ...}

Welcome to the Elastic Beanstalk Command Line Interface (EB CLI). 
For more information on a specific command, type "eb {cmd} --help".
(...)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
