### PR TITLE
Replace "/" to avoid validation error when the most recent git tag has a slash in it

### DIFF
--- a/ebcli/objects/sourcecontrol.py
+++ b/ebcli/objects/sourcecontrol.py
@@ -149,7 +149,7 @@ class Git(SourceControl):
             self._run_cmd(['git', 'describe', '--always', '--abbrev=4'])
 
         version_label = 'app-{}-{:%y%m%d_%H%M%S}'.format(stdout, datetime.datetime.now())
-        return version_label.replace('.', '_')
+        return version_label.replace('.', '_').replace('/', '_')
 
     def untracked_changes_exist(self):
         try:


### PR DESCRIPTION
*Description of changes:*

I have [an app](https://github.com/stefansundin/rssbox) that I deploy to both Heroku and EB. When I deploy to Heroku, I use a gem that automatically tags the deployment so that I (and others) can keep track of when things were deployed (it also automatically creates [nice GitHub releases with a changelog](https://github.com/stefansundin/rssbox/releases)).

The format of these tags are: `heroku/v380`. Unfortunately this causes issues with EB.

When I run `eb deploy`, I get errors like the following:

> ERROR: ServiceError - 1 validation error detected: Value '[app-heroku/v380-200510_112036-stage-200510_112036]' at 'versionLabels' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 100, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [^/]+]

So I created a bash script, [eb-deploy](https://github.com/stefansundin/rssbox/blob/965cc65ea5499a2f6931bdaa3e51bdb24f6e2daa/bin/eb-deploy), that I invoke these days to automatically label the release and that works around the issue.

However, today I decided to investigate more, and this seems to be an easy fix. It appears the cli was already doing this for `.`, so I don't think adding `/` will be that bad. Perhaps all invalid characters should be added to a regex and that be used instead.

I have run this locally and confirmed that it solves the problem for me.

I hope you will consider merging this as it would make my script obsolete. Thank you!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
