### PR TITLE
Update botocore to 1.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import ebcli
 
 
 requires = [
-    'botocore>=1.15,<1.16',
+    'botocore>=1.15,<=1.17',
     'cement==2.8.2',
     'colorama>=0.4,<1.0',  # use the same range that 'docker-compose' uses
     'future>=0.16.0,<0.17.0',


### PR DESCRIPTION
Botocore 1.17 was [just released](https://github.com/boto/botocore/releases/tag/1.17.0). AWS CLI has [updated to it](https://github.com/aws/aws-cli/blob/master/setup.py#L27) already and there is a conflict when installing both `awscli` and `awsebcli` with pip.

```
pkg_resources.ContextualVersionConflict: (botocore 1.17.0 (/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages), Requirement.parse('botocore<1.16,>=1.15'), {'awsebcli'})
 ```

*Description of changes:*

Updates requirements to include Botocore 1.17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
