### PR TITLE
change to compare using equal operator with empty string

### DIFF
--- a/ebcli/controllers/create.py
+++ b/ebcli/controllers/create.py
@@ -218,7 +218,7 @@ class CreateController(AbstractBaseController):
         if (spot_max_price or on_demand_base_capacity or on_demand_above_base_capacity) and not enable_spot:
             raise InvalidOptionsError(strings['create.missing_enable_spot'])
 
-        if instance_types is "":
+        if instance_types == "":
             raise InvalidOptionsError(strings['spot.instance_types_validation'])
 
         if itype and instance_types:


### PR DESCRIPTION
*Description of changes:*

I know that the is operator is used to compare things that use the same memory, such as singletons.
Therefore, the part that was compared with an empty string with the is operator is changed to the == operator.

Let me know if there's anything I'm doing wrong. Thanks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
