### PR TITLE
Don't require needlessly specific versions of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requires = [
     'requests>=2.20.1,<=2.26',
     'setuptools >= 20.0',
     'semantic_version == 2.8.5',
-    'six>=1.11.0,<1.15.0',
+    'six>=1.11.0,<2.0.0',
     'termcolor == 1.1.0',
     'wcwidth>=0.1.7,<0.2.0',
 ]


### PR DESCRIPTION
*Issue #, if available:*

Basically a rehash of #38 since the problem was not actually fixed. It is not possible to install `awsebcli` alongside `aws-sam-cli` because they both pin the minor version of `six` to different things. Pipenv/poetry do not allow this and fail with some kind of error like "version solving failed.":

```
  SolverProblemError

      Because no versions of aws-sam-cli match >1.27.2,<2.0.0
   and aws-sam-cli (1.27.2) depends on aws-sam-translator (1.38.0), aws-sam-cli (>=1.27.2,<2.0.0) requires aws-sam-translator (1.38.0).
  (1) So, because aws-sam-translator (1.38.0) depends on six (>=1.15,<2.0), aws-sam-cli (>=1.27.2,<2.0.0) requires six (>=1.15,<2.0).

      Because awsebcli (3.19.4) depends on six (>=1.11.0,<1.15.0)
   and no versions of awsebcli match >3.19.4,<3.20.0 || >3.20.0,<4.0.0, awsebcli (>=3.19.4,<3.20.0 || >3.20.0,<4.0.0) requires six (>=1.11.0,<1.15.0).
      And because awsebcli (3.20.0) depends on six (>=1.11.0,<1.15.0), awsebcli (>=3.19.4,<4.0.0) requires six (>=1.11.0,<1.15.0).
      And because aws-sam-cli (>=1.27.2,<2.0.0) requires six (>=1.15,<2.0) (1), aws-sam-cli (>=1.27.2,<2.0.0) is incompatible with awsebcli (>=3.19.4,<4.0.0)
      So, because cirrus depends on both awsebcli (^3.19.4) and aws-sam-cli (^1.27.2), version solving failed.
```

*Description of changes:*

There's really no reason to fix the minor version of `six`, If a user needs something more specific, they can pin the version themselves, otherwise it should make no difference until the major version changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
