### PR TITLE
Add `--prefer-private-ip` argument to the `eb ssh` command

### DIFF
--- a/ebcli/controllers/ssh.py
+++ b/ebcli/controllers/ssh.py
@@ -49,6 +49,7 @@ class SSHController(AbstractBaseController):
         force = self.app.pargs.force
         setup = self.app.pargs.setup
         timeout = self.app.pargs.timeout
+        prefer_private_ip = self.app.pargs.prefer_private_ip
 
         if timeout and not setup:
             raise InvalidOptionsError(strings['ssh.timeout_without_setup'])
@@ -62,5 +63,6 @@ class SSHController(AbstractBaseController):
                 number=number,
                 custom_ssh=custom_ssh,
                 command=cmd,
-                timeout=timeout
+                timeout=timeout,
+                prefer_private_ip=prefer_private_ip,
         )

--- a/ebcli/controllers/ssh.py
+++ b/ebcli/controllers/ssh.py
@@ -35,6 +35,8 @@ class SSHController(AbstractBaseController):
             (['--setup'], dict(
                 action='store_true', help=flag_text['ssh.setup'])),
             (['--timeout'], dict(type=int, help=flag_text['ssh.timeout'])),
+            (['--prefer-private-ip'], dict(
+                action='store_true', help=flag_text['ssh.prefer_private_ip'])),
         ]
 
     def do_command(self):

--- a/ebcli/operations/sshops.py
+++ b/ebcli/operations/sshops.py
@@ -28,7 +28,8 @@ LOG = minimal_logger(__name__)
 
 def prepare_for_ssh(env_name, instance, keep_open, force, setup, number,
                     keyname=None, no_keypair_error_message=None,
-                    custom_ssh=None, command=None, timeout=None):
+                    custom_ssh=None, command=None, timeout=None,
+                    prefer_private_ip=False):
     if setup:
         setup_ssh(env_name, keyname, timeout=timeout)
         return
@@ -60,7 +61,8 @@ def prepare_for_ssh(env_name, instance, keep_open, force, setup, number,
             keep_open=keep_open,
             force_open=force,
             custom_ssh=custom_ssh,
-            command=command
+            command=command,
+            prefer_private_ip=prefer_private_ip,
         )
     except NoKeypairError:
         if not no_keypair_error_message:

--- a/ebcli/resources/strings.py
+++ b/ebcli/resources/strings.py
@@ -873,6 +873,7 @@ flag_text = {
     'ssh.setup': 'setup SSH for the environment',
     'ssh.timeout': "Specify the timeout period in minutes. Can only be used with the "
                    "'--setup' argument.",
+    'ssh.prefer_private_ip': "Prefer connecting to an instance's private IP address",
 
     'cleanup.resources': 'Valid values include (builder, versions, all). You can specify '
                          '"builder" to terminate the environment used to create this platform. '

--- a/tests/unit/operations/test_sshops.py
+++ b/tests/unit/operations/test_sshops.py
@@ -324,6 +324,28 @@ class TestSSHOps(unittest.TestCase):
 
     @mock.patch('ebcli.operations.sshops.ec2.describe_instance')
     @mock.patch('ebcli.operations.sshops.ec2.describe_security_group')
+    @mock.patch('ebcli.operations.sshops.ec2.authorize_ssh')
+    @mock.patch('ebcli.operations.sshops._get_ssh_file')
+    @mock.patch('ebcli.operations.sshops.subprocess.call')
+    def test_ssh_into_instance__uses_private_address_when_private_ip_flag_is_present(
+            self,
+            call_mock,
+            _get_ssh_file_mock,
+            authorize_ssh_mock,
+            describe_security_group_mock,
+            describe_instance_mock
+    ):
+        describe_instance_response = deepcopy(mock_responses.DESCRIBE_INSTANCES_RESPONSE['Reservations'][0]['Instances'][0])
+        describe_instance_mock.return_value = describe_instance_response
+        describe_security_group_mock.return_value = mock_responses.DESCRIBE_SECURITY_GROUPS_RESPONSE['SecurityGroups'][0]
+        _get_ssh_file_mock.return_value = 'aws-eb-us-west-2'
+        call_mock.return_value = 0
+
+        sshops.ssh_into_instance('instance-id', prefer_private_ip=True)
+        call_mock.assert_called_once_with(['ssh', '-i', 'aws-eb-us-west-2', 'ec2-user@172.31.35.210'])
+
+    @mock.patch('ebcli.operations.sshops.ec2.describe_instance')
+    @mock.patch('ebcli.operations.sshops.ec2.describe_security_group')
     @mock.patch('ebcli.operations.sshops.ec2.revoke_ssh')
     @mock.patch('ebcli.operations.sshops.ec2.authorize_ssh')
     @mock.patch('ebcli.operations.sshops._get_ssh_file')


### PR DESCRIPTION
*Issue #3*

*Description of changes:*

This is a quality of life improvement for anyone who'd like to run a split-tunnel VPN.

This preserves the existing behavior of the `eb ssh` command but exposes a `--prefer-private-ip` option that uses the instance's private IP before its public one.

I've included a unit test, and I've confirmed this works as expected in my environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
