### PR TITLE
Forcing ssh client to use given private key

### DIFF
--- a/ebcli/operations/sshops.py
+++ b/ebcli/operations/sshops.py
@@ -132,7 +132,7 @@ def ssh_into_instance(instance_id, keep_open=False, force_open=False, custom_ssh
             custom_ssh = custom_ssh.split()
         else:
             ident_file = _get_ssh_file(keypair_name)
-            custom_ssh = ['ssh', '-i', ident_file]
+            custom_ssh = ['ssh', '-i', ident_file, '-o', 'IdentitiesOnly yes']
 
         custom_ssh.extend([user + '@' + ip])
 


### PR DESCRIPTION
*Issue #144

*Description of changes:*
This updates the behavior of EB command `ssh` by adding a new parameter `-o IdentitiesOnly yes` to ssh in order to specify that only identify file of parameter `-i` be presented to ssh server
