### PR TITLE
Update pathspec to 0.10.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ botocore>1.23.41,<1.27.76
 cement==2.8.2
 colorama>=0.2.5,<0.4.4 # use the same range that 'docker-compose' uses
 future>=0.16.0,<0.17.0
-pathspec==0.9.0
+pathspec==0.10.1
 python-dateutil>=2.1,<3.0.0 # use the same range that 'botocore' uses
 requests>=2.20.1,<=2.26
 setuptools >= 20.0


### PR DESCRIPTION
*Description of changes:*

Updating `pathspec` to the [latest released version](https://github.com/cpburnz/python-pathspec/blob/v0.10.1/CHANGES.rst#0101-2022-09-02). I have used a fixed version to follow convention, although I am not sure if that is intentional or if it is just following the pattern established when `pathspec` was first introduced in https://github.com/aws/aws-elastic-beanstalk-cli/commit/8fc17ea3a72a6d786fef452bdc2ecedeb7f57a5f.

This is not urgent, but will help the nixpkgs package collection simplify its build of `awsebcli`, since nixpkgs (almost always) includes only the latest version of a Python package. I am updating `pathspec` in nixpkgs in https://github.com/NixOS/nixpkgs/pull/190845.

Note that this version of `pathspec` drops support for Python 2.7, 3.5, and 3.6, all of which have been EOLed by now. I see that this package still advertises support for Python 2.7, 3.4, and 3.5, and that its `setup.py` has a conditional that checks
for Python versions lower than 3.6. I hope that this advertised support is unintentional and that we can clean all of this up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
