### PR TITLE
Fixed a Unit Test Bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ botocore>1.23.41,<1.27.80
 cement==2.8.2
 colorama>=0.2.5,<0.4.4 # use the same range that 'docker-compose' uses
 future>=0.16.0,<0.17.0
-pathspec==0.9.0
+pathspec==0.10.1
 python-dateutil>=2.1,<3.0.0 # use the same range that 'botocore' uses
 requests>=2.20.1,<=2.26
 setuptools >= 20.0

--- a/tests/unit/operations/test_ebignore.py
+++ b/tests/unit/operations/test_ebignore.py
@@ -140,6 +140,7 @@ directory_2/
         self.assertEqual(
             {
                 'directory_1{}.gitkeep'.format(os.path.sep),
+                'directory_1',
                 'directory_2{}.gitkeep'.format(os.path.sep),
                 '.ebignore'
             },
@@ -206,7 +207,7 @@ directory_1/directory_2/*
         open('file 1', 'w').close()
 
         with open('.ebignore', 'w') as file:
-            ebignore_file_contents = """
+            ebignore_file_contents = r"""
 file\ 1
 """
 
@@ -234,7 +235,7 @@ file\ 1
         open('!file_1', 'w').close()
 
         with open('.ebignore', 'w') as file:
-            ebignore_file_contents = """
+            ebignore_file_contents = r"""
 \!file_1
 """
 
@@ -265,7 +266,7 @@ file\ 1
         open('ändrar något i databasen', 'w').close()
 
         with open('.ebignore', 'wb') as file:
-            ebignore_file_contents = """
+            ebignore_file_contents = r"""
 哈哈
 昨夜のコンサートは最高でした。
 ändrar\ något\ i\ databasen


### PR DESCRIPTION
*Overview:* 
.ebignore includes symlinked files in ignored directories
Fixed [Issue#69](https://github.com/aws/aws-elastic-beanstalk-cli/issues/69)

*Description of changes:*
Fixed bug where a folder mentioned in **.ebignore** file was being included in the final code.zip on running `eb deploy`. This was due to the presence of a **symlink** within that folder.

Changes
1. Added method to check if current file being checked for ignore/include exists in the ignore_list.
2. Updated the **Pathspec** library to latest version i.e. **0.10.1**
3. Changed method in get_ebignore_list() function from match_tree to math_tree_entries.

> .ebignore contents = ignore/ , Before: we were getting ignore/.... but not just ignore/ After: we get ignore/... and just ignore/ too.

4. Updated Unit test case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
