### PR TITLE
fix syntax warning

### DIFF
--- a/ebcli/controllers/create.py
+++ b/ebcli/controllers/create.py
@@ -218,7 +218,7 @@ class CreateController(AbstractBaseController):
         if (spot_max_price or on_demand_base_capacity or on_demand_above_base_capacity) and not enable_spot:
             raise InvalidOptionsError(strings['create.missing_enable_spot'])
 
-        if instance_types is "":
+        if instance_types == "":
             raise InvalidOptionsError(strings['spot.instance_types_validation'])
 
         if itype and instance_types:


### PR DESCRIPTION
*Issue #, if available:*

```
/opt/homebrew/Cellar/aws-elasticbeanstalk/3.20.3_1/libexec/lib/python3.11/site-packages/ebcli/controllers/create.py:221: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if instance_types is "":
```
