### PR TITLE
change botocore back to <1.29.81

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-botocore>1.23.41,<1.29.82
+botocore>1.23.41,<1.29.81
 cement==2.8.2
 colorama>=0.2.5,<0.4.4 # use the same range that 'docker-compose' uses
 pathspec==0.10.1


### PR DESCRIPTION
*Issue #, if available:*

Fixes #327

*Description of changes:*

Dependabot [changed botocore to <*.82](https://github.com/aws/aws-elastic-beanstalk-cli/commit/670f846bcd0eaa5ab0c0deed032bcec3cde34438) instead of keeping it <*.81 as suggested by the [changelog](https://github.com/aws/aws-elastic-beanstalk-cli/commit/9d5ce78b7c77c935f9fcd8b80a9c00575de1b289) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
