### PR TITLE
Codebuild bugfix

### DIFF
--- a/ebcli/lib/iam.py
+++ b/ebcli/lib/iam.py
@@ -36,12 +36,23 @@ def get_instance_profiles():
     return result['InstanceProfiles']
 
 
-def get_roles(marker=None):
-    if marker:
-        result = _make_api_call('list_roles', Marker=marker)
-    else:
-        result = _make_api_call('list_roles')
-    return result
+def get_roles():
+    isTruncated = True
+    marker = ''
+    roles = []
+    while isTruncated:
+        if marker == '':
+            result = _make_api_call('list_roles')
+        else:
+            result = _make_api_call('list_roles', Marker=marker)
+        isTruncated = result['IsTruncated']
+        existing_roles = result['Roles']
+        for role in existing_roles:
+            roles.append(role)
+        if isTruncated:
+            marker = result['Marker']
+
+    return roles
 
 
 def get_role(role_name):
@@ -77,8 +88,7 @@ def get_instance_profile_names():
 
 
 def get_role_names():
-    result = get_roles()
-    roles = result['Roles']
+    roles = get_roles()
     lst = []
     for role in roles:
         lst.append(role['RoleName'])

--- a/ebcli/lib/iam.py
+++ b/ebcli/lib/iam.py
@@ -36,8 +36,8 @@ def get_instance_profiles():
     return result['InstanceProfiles']
 
 
-def get_all_roles(Marker):
-    result = _make_api_call('list_roles', Marker=Marker)
+def get_all_roles(marker):
+    result = _make_api_call('list_roles', Marker=marker)
     return result
 
 

--- a/ebcli/lib/iam.py
+++ b/ebcli/lib/iam.py
@@ -36,19 +36,12 @@ def get_instance_profiles():
     return result['InstanceProfiles']
 
 
-def get_all_roles(marker):
-    result = _make_api_call('list_roles', Marker=marker)
+def get_roles(marker=None):
+    if marker:
+        result = _make_api_call('list_roles', Marker=marker)
+    else:
+        result = _make_api_call('list_roles')
     return result
-
-
-def get_all_roles_without_marker():
-    result = _make_api_call('list_roles')
-    return result
-
-
-def get_roles():
-    result = _make_api_call('list_roles')
-    return result['Roles']
 
 
 def get_role(role_name):
@@ -84,7 +77,8 @@ def get_instance_profile_names():
 
 
 def get_role_names():
-    roles = get_roles()
+    result = get_roles()
+    roles = result['Roles']
     lst = []
     for role in roles:
         lst.append(role['RoleName'])

--- a/ebcli/lib/iam.py
+++ b/ebcli/lib/iam.py
@@ -36,6 +36,16 @@ def get_instance_profiles():
     return result['InstanceProfiles']
 
 
+def get_all_roles(Marker):
+    result = _make_api_call('list_roles', Marker=Marker)
+    return result
+
+
+def get_all_roles_without_marker():
+    result = _make_api_call('list_roles')
+    return result
+
+
 def get_roles():
     result = _make_api_call('list_roles')
     return result['Roles']

--- a/ebcli/operations/buildspecops.py
+++ b/ebcli/operations/buildspecops.py
@@ -102,7 +102,7 @@ def validate_build_config(build_config):
                 break
             if isTruncated and validated_role is None:
                 marker = result['Marker']
-                result = get_all_roles(Marker=marker)
+                result = get_all_roles(marker)
                 existing_roles = result['Roles']
             if isTruncated == False and validated_role is None:
                 my_flag = False

--- a/ebcli/operations/buildspecops.py
+++ b/ebcli/operations/buildspecops.py
@@ -82,23 +82,11 @@ def validate_build_config(build_config):
         from ebcli.lib.iam import get_roles
         role = build_config.service_role
         validated_role = None
-        isTruncated = True
-        marker = ''
-        while isTruncated and validated_role is None:
-            if marker == '':
-                result = get_roles()
-            else:
-                result = get_roles(marker)
-            
-            isTruncated = result['IsTruncated']
-            existing_roles = result['Roles']
-            
-            for existing_role in existing_roles:
-                if role == existing_role['Arn'] or role == existing_role['RoleName']:
-                    validated_role = existing_role['Arn']
-                    break
-            if isTruncated:
-                marker = result['Marker']
+        existing_roles = get_roles()
+        for existing_role in existing_roles:
+            if role == existing_role['Arn'] or role == existing_role['RoleName']:
+                validated_role = existing_role['Arn']
+                break
 
         if validated_role is None:
             LOG.debug("Role '{0}' not found in retrieved list of roles".format(role))

--- a/ebcli/operations/buildspecops.py
+++ b/ebcli/operations/buildspecops.py
@@ -79,13 +79,33 @@ def stream_build_configuration_app_version_creation(app_name, app_version_label,
 
 def validate_build_config(build_config):
     if build_config.service_role is not None:
-        from ebcli.lib.iam import get_roles
+        from ebcli.lib.iam import get_all_roles, get_all_roles_without_marker
         role = build_config.service_role
         validated_role = None
-        existing_roles = get_roles()
-        for existing_role in existing_roles:
-            if role == existing_role['Arn'] or role == existing_role['RoleName']:
-                validated_role = existing_role['Arn']
+        isTruncated = True
+        marker = ''
+        result = {}
+        result = get_all_roles_without_marker()
+        existing_roles = []
+        existing_role = {}
+        existing_roles = result['Roles']
+        
+        my_flag = True
+        while my_flag and validated_role is None:
+            
+            isTruncated = result['IsTruncated']
+            
+            for existing_role in existing_roles:
+                if role == existing_role['Arn'] or role == existing_role['RoleName']:
+                    validated_role = existing_role['Arn']
+            if validated_role is not None:
+                break
+            if isTruncated and validated_role is None:
+                marker = result['Marker']
+                result = get_all_roles(Marker=marker)
+                existing_roles = result['Roles']
+            if isTruncated == False and validated_role is None:
+                my_flag = False
 
         if validated_role is None:
             LOG.debug("Role '{0}' not found in retrieved list of roles".format(role))

--- a/ebcli/operations/buildspecops.py
+++ b/ebcli/operations/buildspecops.py
@@ -79,33 +79,26 @@ def stream_build_configuration_app_version_creation(app_name, app_version_label,
 
 def validate_build_config(build_config):
     if build_config.service_role is not None:
-        from ebcli.lib.iam import get_all_roles, get_all_roles_without_marker
+        from ebcli.lib.iam import get_roles
         role = build_config.service_role
         validated_role = None
         isTruncated = True
         marker = ''
-        result = {}
-        result = get_all_roles_without_marker()
-        existing_roles = []
-        existing_role = {}
-        existing_roles = result['Roles']
-        
-        my_flag = True
-        while my_flag and validated_role is None:
+        while isTruncated and validated_role is None:
+            if marker == '':
+                result = get_roles()
+            else:
+                result = get_roles(marker)
             
             isTruncated = result['IsTruncated']
+            existing_roles = result['Roles']
             
             for existing_role in existing_roles:
                 if role == existing_role['Arn'] or role == existing_role['RoleName']:
                     validated_role = existing_role['Arn']
-            if validated_role is not None:
-                break
-            if isTruncated and validated_role is None:
+                    break
+            if isTruncated:
                 marker = result['Marker']
-                result = get_all_roles(marker)
-                existing_roles = result['Roles']
-            if isTruncated == False and validated_role is None:
-                my_flag = False
 
         if validated_role is None:
             LOG.debug("Role '{0}' not found in retrieved list of roles".format(role))

--- a/tests/unit/operations/test_buildspecops.py
+++ b/tests/unit/operations/test_buildspecops.py
@@ -62,7 +62,7 @@ class TestBuildSpecOps(unittest.TestCase):
                                        u'Arn': 'arn:aws:iam::123456789098:role/service-role/aws-codebuild-role'
                                        }]
     
-    list_roles_without_marker_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
+    list_roles_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
                                            {u'Version': u'2012-10-17', u'Statement': [
                                                {u'Action': u'sts:AssumeRole', u'Effect': u'Allow',
                                                 u'Principal': {u'Service': u'codebuild.amazonaws.com'}}]},
@@ -187,33 +187,33 @@ class TestBuildSpecOps(unittest.TestCase):
 
         self.assertRaises(ValidationError, buildspecops.validate_build_config, build_config)
 
-    @mock.patch('ebcli.lib.iam.get_all_roles_without_marker')
-    def test_validate_build_config_without_image(self, mock_get_all_roles_without_marker):
+    @mock.patch('ebcli.lib.iam.get_roles')
+    def test_validate_build_config_without_image(self, mock_get_roles):
         build_config = copy.deepcopy(self.build_config)
         build_config.image = None 
-        mock_get_all_roles_without_marker.return_value = self.list_roles_without_marker_response_as_dict
+        mock_get_roles.return_value = self.list_roles_response_as_dict
         
         self.assertRaises(ValidationError, buildspecops.validate_build_config, build_config)
 
-        mock_get_all_roles_without_marker.assert_called_with()
+        mock_get_roles.assert_called_with()
 
-    @mock.patch('ebcli.lib.iam.get_all_roles_without_marker')
-    def test_validate_build_config_with_invalid_role(self, mock_get_all_roles_without_marker):
+    @mock.patch('ebcli.lib.iam.get_roles')
+    def test_validate_build_config_with_invalid_role(self, mock_get_roles):
         build_config = copy.deepcopy(self.build_config)
         build_config.service_role = 'bad-role'
-        mock_get_all_roles_without_marker.return_value = self.list_roles_without_marker_response_as_dict
+        mock_get_roles.return_value = self.list_roles_response_as_dict
 
         self.assertRaises(ValidationError, buildspecops.validate_build_config, build_config)
 
-        mock_get_all_roles_without_marker.assert_called_with()
+        mock_get_roles.assert_called_with()
 
-    @mock.patch('ebcli.lib.iam.get_all_roles_without_marker')
-    def test_validate_build_config_happy_case(self, mock_get_all_roles_without_marker):
-        mock_get_all_roles_without_marker.return_value = self.list_roles_without_marker_response_as_dict
+    @mock.patch('ebcli.lib.iam.get_roles')
+    def test_validate_build_config_happy_case(self, mock_get_roles):
+        mock_get_roles.return_value = self.list_roles_response_as_dict
 
         buildspecops.validate_build_config(self.build_config)
 
-        mock_get_all_roles_without_marker.assert_called_with()
+        mock_get_roles.assert_called_with()
 
     @mock.patch('ebcli.operations.buildspecops.elasticbeanstalk.get_application_versions')
     @mock.patch('ebcli.operations.buildspecops.io.log_error')

--- a/tests/unit/operations/test_buildspecops.py
+++ b/tests/unit/operations/test_buildspecops.py
@@ -61,18 +61,6 @@ class TestBuildSpecOps(unittest.TestCase):
                                        u'Path': '/service-role/',
                                        u'Arn': 'arn:aws:iam::123456789098:role/service-role/aws-codebuild-role'
                                        }]
-    
-    list_roles_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
-                                           {u'Version': u'2012-10-17', u'Statement': [
-                                               {u'Action': u'sts:AssumeRole', u'Effect': u'Allow',
-                                                u'Principal': {u'Service': u'codebuild.amazonaws.com'}}]},
-                                       u'RoleName': 'aws-codebuild-role',
-                                       u'Path': '/service-role/',
-                                       u'Arn': 'arn:aws:iam::123456789098:role/service-role/aws-codebuild-role'
-                                       }],
-                                       u'IsTruncated': False,
-                                       u'Marker': r'\u+0031'
-    }
 
     def setUp(self):
         self.patcher_beanstalk = mock.patch('ebcli.operations.buildspecops.elasticbeanstalk')
@@ -191,7 +179,7 @@ class TestBuildSpecOps(unittest.TestCase):
     def test_validate_build_config_without_image(self, mock_get_roles):
         build_config = copy.deepcopy(self.build_config)
         build_config.image = None 
-        mock_get_roles.return_value = self.list_roles_response_as_dict
+        mock_get_roles.return_value = self.list_roles_response
         
         self.assertRaises(ValidationError, buildspecops.validate_build_config, build_config)
 
@@ -201,7 +189,7 @@ class TestBuildSpecOps(unittest.TestCase):
     def test_validate_build_config_with_invalid_role(self, mock_get_roles):
         build_config = copy.deepcopy(self.build_config)
         build_config.service_role = 'bad-role'
-        mock_get_roles.return_value = self.list_roles_response_as_dict
+        mock_get_roles.return_value = self.list_roles_response
 
         self.assertRaises(ValidationError, buildspecops.validate_build_config, build_config)
 
@@ -209,7 +197,7 @@ class TestBuildSpecOps(unittest.TestCase):
 
     @mock.patch('ebcli.lib.iam.get_roles')
     def test_validate_build_config_happy_case(self, mock_get_roles):
-        mock_get_roles.return_value = self.list_roles_response_as_dict
+        mock_get_roles.return_value = self.list_roles_response
 
         buildspecops.validate_build_config(self.build_config)
 

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -61,7 +61,7 @@ class TestCommonOperations(unittest.TestCase):
     image = 'aws/codebuild/eb-java-8-amazonlinux-64:2.1.3'
     compute_type = 'BUILD_GENERAL1_SMALL'
     service_role = 'eb-test'
-    list_roles_without_marker_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
+    list_roles_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
                                            {u'Version': u'2012-10-17', u'Statement': [
                                                {u'Action': u'sts:AssumeRole', u'Effect': u'Allow',
                                                 u'Principal': {u'Service': u'codebuild.amazonaws.com'}}]},
@@ -237,8 +237,8 @@ class TestCommonOperations(unittest.TestCase):
 
     @mock.patch('ebcli.operations.commonops.elasticbeanstalk')
     def test_create_application_version_wrapper_with_build_config(self, mock_beanstalk):
-        with mock.patch('ebcli.lib.iam.get_all_roles_without_marker') as mock_iam_get_roles:
-            mock_iam_get_roles.return_value = self.list_roles_without_marker_response_as_dict
+        with mock.patch('ebcli.lib.iam.get_roles') as mock_iam_get_roles:
+            mock_iam_get_roles.return_value = self.list_roles_response_as_dict
 
             actual_return = commonops._create_application_version(self.app_name, self.app_version_name,
                                                   self.description, self.s3_bucket, self.s3_key, build_config=self.build_config)

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -61,7 +61,17 @@ class TestCommonOperations(unittest.TestCase):
     image = 'aws/codebuild/eb-java-8-amazonlinux-64:2.1.3'
     compute_type = 'BUILD_GENERAL1_SMALL'
     service_role = 'eb-test'
-    service_role_arn = 'arn:testcli:eb-test'
+    list_roles_without_marker_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
+                                           {u'Version': u'2012-10-17', u'Statement': [
+                                               {u'Action': u'sts:AssumeRole', u'Effect': u'Allow',
+                                                u'Principal': {u'Service': u'codebuild.amazonaws.com'}}]},
+                                       u'RoleName': 'eb-test',
+                                       u'Path': '/service-role/',
+                                       u'Arn': 'arn:aws:iam::123456789098:role/service-role/aws-codebuild-role'
+                                       }],
+                                       u'IsTruncated': False,
+                                       u'Marker': r'\u+0031'
+    }
     timeout = 60
     build_config = BuildConfiguration(image=image, compute_type=compute_type,
                                       service_role=service_role, timeout=timeout)
@@ -227,9 +237,8 @@ class TestCommonOperations(unittest.TestCase):
 
     @mock.patch('ebcli.operations.commonops.elasticbeanstalk')
     def test_create_application_version_wrapper_with_build_config(self, mock_beanstalk):
-        with mock.patch('ebcli.lib.iam.get_roles') as mock_iam_get_roles:
-            mock_iam_get_roles.return_value = [{'RoleName': self.service_role, 'Arn': self.service_role_arn},
-                                               {'RoleName': self.service_role, 'Arn': self.service_role_arn}]
+        with mock.patch('ebcli.lib.iam.get_all_roles_without_marker') as mock_iam_get_roles:
+            mock_iam_get_roles.return_value = self.list_roles_without_marker_response_as_dict
 
             actual_return = commonops._create_application_version(self.app_name, self.app_version_name,
                                                   self.description, self.s3_bucket, self.s3_key, build_config=self.build_config)

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -61,17 +61,7 @@ class TestCommonOperations(unittest.TestCase):
     image = 'aws/codebuild/eb-java-8-amazonlinux-64:2.1.3'
     compute_type = 'BUILD_GENERAL1_SMALL'
     service_role = 'eb-test'
-    list_roles_response_as_dict = { u'Roles':[{u'AssumeRolePolicyDocument':
-                                           {u'Version': u'2012-10-17', u'Statement': [
-                                               {u'Action': u'sts:AssumeRole', u'Effect': u'Allow',
-                                                u'Principal': {u'Service': u'codebuild.amazonaws.com'}}]},
-                                       u'RoleName': 'eb-test',
-                                       u'Path': '/service-role/',
-                                       u'Arn': 'arn:aws:iam::123456789098:role/service-role/aws-codebuild-role'
-                                       }],
-                                       u'IsTruncated': False,
-                                       u'Marker': r'\u+0031'
-    }
+    service_role_arn = 'arn:aws:iam::123456789123:role/eb-test'
     timeout = 60
     build_config = BuildConfiguration(image=image, compute_type=compute_type,
                                       service_role=service_role, timeout=timeout)
@@ -238,7 +228,8 @@ class TestCommonOperations(unittest.TestCase):
     @mock.patch('ebcli.operations.commonops.elasticbeanstalk')
     def test_create_application_version_wrapper_with_build_config(self, mock_beanstalk):
         with mock.patch('ebcli.lib.iam.get_roles') as mock_iam_get_roles:
-            mock_iam_get_roles.return_value = self.list_roles_response_as_dict
+            mock_iam_get_roles.return_value = [{'RoleName': self.service_role, 'Arn': self.service_role_arn},
+                                               {'RoleName': self.service_role, 'Arn': self.service_role_arn}]
 
             actual_return = commonops._create_application_version(self.app_name, self.app_version_name,
                                                   self.description, self.s3_bucket, self.s3_key, build_config=self.build_config)


### PR DESCRIPTION
*Issue:*
When codebuild is used, a buildspec.yml file is present in the application package. It has configuration settings for incorporating codebuild in your application. The CodeBuildServiceRole given in that file can be either an arn (arn:aws:iam::123456789123:role/aaa1234) or (arn:aws:iam::123456789123:role/service-role/zzxxyy) or just role-name (codebuild-service-role-zzxxyy). In ebcli codebase we call the iam.list_roles api to get all the iam roles. There is a limit on the count retrieved by default(100). Earlier, if there were more than 100 roles in IAM it was throwing an exception if the role wasn't fetched in the first 100 itself.

*Description of changes:*
Solved this by checking for more roles after the first api call and searching for the desired role until all roles present in IAM were checked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
