### PR TITLE
Platform Bugfix

### DIFF
--- a/ebcli/objects/solutionstack.py
+++ b/ebcli/objects/solutionstack.py
@@ -405,6 +405,7 @@ class SolutionStack(object):
 
         :return: A SolutionStack object representing the input language name
         """
+        solution_stack_list = sorted(solution_stack_list)
         for solution_stack in solution_stack_list:
             if solution_stack.language_name.lower() == language_name.lower():
                 return solution_stack


### PR DESCRIPTION
*Description of changes:*
EBCLI was picking up older Corretto version (Corretto 8) for java when running command: `eb create --single -p "corretto"`. Instead it should choose Corretto 17 which is the latest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
