### PR TITLE
deps: update `six` constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dateutil>=2.1,<3.0.0 # use the same range that 'botocore' uses
 requests>=2.31
 setuptools >= 20.0
 semantic_version == 2.8.5
-six>=1.11.0,<1.15.0
+six>=1.11.0,<1.17.0
 termcolor == 1.1.0
 wcwidth>=0.1.7,<0.2.0
 PyYAML>=5.3.1,<5.5 # use the same range that 'aws-cli' uses. This is also compatible with 'docker-compose'


### PR DESCRIPTION
seeing some issue in https://github.com/Homebrew/homebrew-core/pull/136977

```
pkg_resources.DistributionNotFound: The 'six<1.15.0,>=1.11.0' distribution was not found and is required by awsebcli
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
