### PR TITLE
Update urllib3 in  requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ six>=1.11.0,<1.15.0
 termcolor == 1.1.0
 wcwidth>=0.1.7,<0.2.0
 PyYAML>=5.3.1,<6.1 # use the same range that 'aws-cli' uses. This is also compatible with 'docker-compose'
-urllib3>=1.26.5 #1.26.5 fix CVE-2021-33503
+urllib3>=1.26.5,<2 #1.26.5 fix CVE-2021-33503


### PR DESCRIPTION
*Issue #, if available:385

*Description of changes:This fixes an incompatibility regarding DEFAULT_CIPHERS being removed in urllib3 v2 by pinning urllib3 on >=1.26.5, <2. Resolved merge conflicts and updated code as per pull request .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.