### PR TITLE
remove duplication with entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup_options = dict(
     version=ebcli.__version__,
     description='Command Line Interface for AWS EB.',
     long_description=open('README.rst').read() + open('CHANGES.rst').read(),
-    scripts=['bin/eb'],
     data_files=[('', ['requirements.txt'])],
     author='AWS Elastic Beanstalk',
     author_email='aws-eb-cli@amazon.com',


### PR DESCRIPTION
installing awebcli using https://github.com/pypa/installer fails due to eb being listed in both `scripts` and `entry_points`


```
error: builder for '/nix/store/swk28rqdv15g8v383al28kzjvigdp4y8-awsebcli-3.20.7.drv' failed with exit code 1;
       last 10 log lines:
       >     _main(sys.argv[1:], "python -m installer")
       >   File "/nix/store/qg1mq5b71pbhnvpa8l1024prdymn2hkc-python3.10-installer-0.7.0/lib/python3.10/site-packages/installer/__main__.py", line 94, in _main
       >     installer.install(source, destination, {})
       >   File "/nix/store/qg1mq5b71pbhnvpa8l1024prdymn2hkc-python3.10-installer-0.7.0/lib/python3.10/site-packages/installer/_core.py", line 109, in install
       >     record = destination.write_file(
       >   File "/nix/store/qg1mq5b71pbhnvpa8l1024prdymn2hkc-python3.10-installer-0.7.0/lib/python3.10/site-packages/installer/destinations.py", line 203, in write_file
       >     return self.write_to_fs(
       >   File "/nix/store/qg1mq5b71pbhnvpa8l1024prdymn2hkc-python3.10-installer-0.7.0/lib/python3.10/site-packages/installer/destinations.py", line 167, in write_to_fs
       >     raise FileExistsError(message)
       > FileExistsError: File already exists: /nix/store/jr3mlipbs9s578brpwmbcppbbvd52hzd-awsebcli-3.20.7/bin/eb
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
