### PR TITLE
Test

### DIFF
--- a/ebcli/controllers/create.py
+++ b/ebcli/controllers/create.py
@@ -218,7 +218,7 @@ class CreateController(AbstractBaseController):
         if (spot_max_price or on_demand_base_capacity or on_demand_above_base_capacity) and not enable_spot:
             raise InvalidOptionsError(strings['create.missing_enable_spot'])
 
-        if instance_types is "":
+        if instance_types == "":
             raise InvalidOptionsError(strings['spot.instance_types_validation'])
 
         if itype and instance_types:

--- a/ebcli/display/screen.py
+++ b/ebcli/display/screen.py
@@ -439,10 +439,7 @@ class Screen(object):
         scrolled = visible_tables[0].scroll_down(reverse=reverse)
         if scrolled:
             for i in range(1, len(visible_tables)):
-                assert(
-                    len(visible_tables[0].data) >= len(visible_tables[i].data),
-                    'First table should be the largest'
-                )
+                assert len(visible_tables[0].data) >= len(visible_tables[i].data),'First table should be the largest'
                 visible_tables[i].scroll_to_id(scrolled, reverse=reverse)
 
     def scroll_over(self, reverse=False):

--- a/ebcli/lib/codebuild.py
+++ b/ebcli/lib/codebuild.py
@@ -57,7 +57,7 @@ def list_curated_environment_images():
     each available platform from CodeBuild.
     :return: array of image dictionaries
     """
-    regex_search_version = "AWS ElasticBeanstalk - (.*)v([0-9]+\.[0-9]+\.[0-9]+)"
+    regex_search_version = r"AWS ElasticBeanstalk - (.*?)v([0-9]+\.[0-9]+\.[0-9]+)"
     result = _make_api_call('list_curated_environment_images')
     beanstalk_images = []
     for platform in result['platforms']:

--- a/tests/unit/operations/tagops/test_taglist.py
+++ b/tests/unit/operations/tagops/test_taglist.py
@@ -134,7 +134,7 @@ class ArgumentSyntaxValidatorTest(unittest.TestCase):
         Python identifies certain Unicode characters as letters, but not others.
 
         For example, the greek delta symbol is not a Unicode letter, and hence
-        will not match `\w` during regex comparisons, whereas the Swedish `a`
+        will not match `\\w` during regex comparisons, whereas the Swedish `a`
         is a letter.
 
         It is also to be noted that even if Python recognizes a Unicode character

--- a/tests/unit/operations/test_envvarops.py
+++ b/tests/unit/operations/test_envvarops.py
@@ -30,7 +30,7 @@ class TestEnvvarOps(unittest.TestCase):
             Counter(frozenset(iteritems(d)) for d in ls2))
 
     def test_sanitize_environment_variables_from_customer_input(self):
-        environment_variables_input = '  """  DB_USER"""   =     "\"  r=o\"o\'t\"\"  "   ,  DB_PAS\ = SWORD="\"pass=\'\"word\""'
+        environment_variables_input = '  """  DB_USER"""   =     "\"  r=o\"o\'t\"\"  "   ,  DB_PAS\\ = SWORD="\"pass=\'\"word\""'
 
         self.assertEqual(
             [


### PR DESCRIPTION
*Issue #9, if available:*

*Description of changes:*
Modified to remove warnings as shown 
ebcli/lib/codebuild.py:60
  /codebuild/output/src491/src/github.com/aws/aws-elastic-beanstalk-cli/ebcli/lib/codebuild.py:60: DeprecationWarning: invalid escape sequence \.
    regex_search_version = "AWS ElasticBeanstalk - (.*)v([0-9]+\.[0-9]+\.[0-9]+)"

ebcli/display/screen.py:442
  /codebuild/output/src491/src/github.com/aws/aws-elastic-beanstalk-cli/ebcli/display/screen.py:442: SyntaxWarning: assertion is always true, perhaps remove parentheses?
    assert(

ebcli/controllers/create.py:221
  /codebuild/output/src491/src/github.com/aws/aws-elastic-beanstalk-cli/ebcli/controllers/create.py:221: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if instance_types is "":

tests/unit/operations/test_envvarops.py:33
  /codebuild/output/src491/src/github.com/aws/aws-elastic-beanstalk-cli/tests/unit/operations/test_envvarops.py:33: DeprecationWarning: invalid escape sequence \
    environment_variables_input = '  """  DB_USER"""   =     "\"  r=o\"o\'t\"\"  "   ,  DB_PAS\ = SWORD="\"pass=\'\"word\""'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
