### PR TITLE
Pin cement dependency to 2.10.14 to allow EB CLI to work with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 botocore>1.23.41,<1.35.0
-cement==2.8.2
+cement==2.10.14
 colorama>=0.2.5,<0.4.4 # use the same range that 'docker-compose' uses
 pathspec==0.10.1
 python-dateutil>=2.1,<3.0.0 # use the same range that 'botocore' uses


### PR DESCRIPTION
See: https://github.com/datafolklabs/cement/pull/673

*Issue #, if available:* https://github.com/aws/aws-elastic-beanstalk-cli/issues/493

*Description of changes:* Cement 2.10.14 avoids importing `imp` in versions of Python it is deprecated in. This commit upgrades Cement to Python 2.10.14.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
