### PR TITLE
let `eb local run` generate multi-service docker-compose files

### DIFF
--- a/ebcli/containers/compose.py
+++ b/ebcli/containers/compose.py
@@ -18,6 +18,7 @@ from ebcli.containers.envvarcollector import EnvvarCollector
 
 
 AWSEB_LOGS = 'awseb-logs-'
+COMPOSE_SERVICES_KEY = 'services'
 COMPOSE_CMD_KEY = 'command'
 COMPOSE_ENV_KEY = 'environment'
 COMPOSE_IMG_KEY = 'image'
@@ -76,7 +77,7 @@ def compose_dict(dockerrun, docker_proj_path, host_log, high_priority_env):
     for definition in definitions:
         _add_service(services, definition, volume_map, host_log, high_priority_env)
 
-    return services
+    return {COMPOSE_SERVICES_KEY: services}
 
 
 def _add_service(services, definition, volume_map, host_log, high_priority_env):


### PR DESCRIPTION
partially fixes #58, but ideally a full fix would just copy a docker-compose.yml at the root if one existed

this just fixes improperly dumping multiple services at the root of the docker-compose and failing validation

also it ideally would work with the "ECS" image and not just "Multi-container Docker"

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
