### PR TITLE
Dirty fix for race conditions on complete_multipart_uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /dist
 /out
 eb.py
-awsebcli.egg-info/
+awsebcli_inscribe.egg-info/
 .eggs/
 *.DS_Store
 .cache/

--- a/ebcli/__init__.py
+++ b/ebcli/__init__.py
@@ -11,4 +11,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-__version__ = '3.20.10'
+__version__ = '3.20.10+inscribe'

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ if not sys.platform.startswith('win'):
 
 
 setup_options = dict(
-    name='awsebcli',
+    name='awsebcli_inscribe',
     version=ebcli.__version__,
-    description='Command Line Interface for AWS EB.',
+    description='Command Line Interface for AWS EB (Inscribe fork).',
     long_description=open('README.rst').read() + open('CHANGES.rst').read(),
     scripts=['bin/eb'],
     data_files=[('', ['requirements.txt'])],


### PR DESCRIPTION
Sporadically, the calls on `complete_multipart_upload` fail with the following pattern:

- We get the following error: `ebcli.objects.exceptions.ServiceError: One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.`
- The multipart upload itself disappears afterwards. This can only happen if it is aborted/completed (the latter in our case, contradicting the previous error). I have double checked that the part list and the associated etags that the CLI appends to this call are correct.
- At this point, retrying the original call will always end up in `ebcli.objects.exceptions.NotFoundError: The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.`. Because the upload has indeed been completed.

I suspect the problems arise from the [multithreaded logic for doing multipart uploads](https://github.com/aws/aws-elastic-beanstalk-cli/blob/master/ebcli/lib/s3.py#L181-L197), leading to race conditions.

As a "dirty fix" for this problem, allowing retries on `ServiceError` and continuing on `NotFoundError` (if `attempt > 1`) on behalf of `complete_multipart_upload` calls, while the AWS EB team looks into this problem.