### PR TITLE
Support 'eb deploy ... --archive <ZIP|dir>'

### DIFF
--- a/ebcli/controllers/deploy.py
+++ b/ebcli/controllers/deploy.py
@@ -10,18 +10,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-from os import path, chdir, getcwd
+from os import path, chdir, getcwd, makedirs
+import zipfile
+import datetime
+from typing import Optional
 
 from cement.utils.misc import minimal_logger
 
 from ebcli.core import io, hooks, fileoperations
 from ebcli.core.abstractcontroller import AbstractBaseController
-from ebcli.lib import elasticbeanstalk, utils
-from ebcli.objects.exceptions import InvalidOptionsError
+from ebcli.lib import elasticbeanstalk
+from ebcli.objects.environment import Environment
+from ebcli.objects.exceptions import InvalidOptionsError, NotInitializedError
 from ebcli.operations import commonops, deployops, composeops, statusops
-from ebcli.resources.strings import strings, flag_text, alerts
-from ebcli.resources.statics import platform_branch_lifecycle_states
+from ebcli.resources.strings import strings, flag_text
 
 LOG = minimal_logger(__name__)
 
@@ -47,7 +49,8 @@ class DeployController(AbstractBaseController):
             (['--source'], dict(help=flag_text['deploy.source'])),
             (['-p', '--process'], dict(
                 action='store_true', help=flag_text['deploy.process'])),
-            ]
+            (['--archive'], dict(help=flag_text['deploy.archive'])),]
+
         usage = AbstractBaseController.Meta.usage.replace('{cmd}', label)
 
     def do_command(self):
@@ -62,9 +65,28 @@ class DeployController(AbstractBaseController):
         self.message = self.app.pargs.message
         self.staged = self.app.pargs.staged
         self.source = self.app.pargs.source
-        self.app_name = self.get_app_name()
-        self.env_name = self.get_env_name()
+        self.archive = self.app.pargs.archive
+        if self.archive and not self.app.pargs.region:
+            raise InvalidOptionsError(strings['deploy.archivewithoutregion'])
+        if self.source and self.archive:
+            raise InvalidOptionsError(strings['deploy.archivewithsource'])
+
+        self.env_name = self.app.pargs.environment_name
+        if self.archive and not self.env_name:
+            raise InvalidOptionsError(strings['deploy.archivewithoutenvname'])
+        elif not self.archive:
+            self.env_name = self.env_name or self.get_env_name()
+
+        if self.archive:
+            environment = elasticbeanstalk.get_environment(env_name=self.env_name)
+            self.app_name = environment.app_name
+        else:
+            self.app_name = self.get_app_name()
+
         self.version = self.app.pargs.version
+        if self.version and self.archive:
+            raise InvalidOptionsError(strings['deploy.archivewithversion'])
+
         self.label = self.app.pargs.label
         self.process = self.app.pargs.process
         group_name = self.app.pargs.env_group_suffix
@@ -76,9 +98,15 @@ class DeployController(AbstractBaseController):
 
         process_app_versions = fileoperations.env_yaml_exists() or self.process
 
+        source_bundle_zip = None
+        if self.archive:
+            source_bundle_zip = get_or_create_source_bundle(archive=self.archive, label=self.label)
+            self.label = self.label or source_bundle_zip.split(path.sep)[-1]
+
         deployops.deploy(self.app_name, self.env_name, self.version, self.label,
                          self.message, group_name=group_name, process_app_versions=process_app_versions,
-                         staged=self.staged, timeout=self.timeout, source=self.source)
+                         staged=self.staged, timeout=self.timeout, source=self.source,
+                         source_bundle=source_bundle_zip)
 
     def multiple_app_deploy(self):
         missing_env_yaml = []
@@ -181,3 +209,25 @@ class DeployController(AbstractBaseController):
 def _check_env_lifecycle_state(env_name):
     env = elasticbeanstalk.get_environment(env_name=env_name)
     statusops.alert_environment_status(env)
+
+
+def get_or_create_source_bundle(archive: str, label: str=None) -> Optional[str]:
+    if archive and zipfile.is_zipfile(archive):
+        source_bundle_zip = archive
+    elif archive and path.isdir(archive):
+        upload_target_dir = archive
+        utcnow = str(datetime.datetime.now(datetime.UTC).timestamp())
+        migrations_path = path.join(path.expanduser('~'), '.ebartifacts')
+        if label:
+            zip_file_name = f"{label}.zip"
+        else:
+            zip_file_name = f"archives-{utcnow}.zip"
+        source_bundle_zip = path.join(migrations_path, 'archives', zip_file_name)
+        makedirs(path.join(migrations_path, 'archives'), exist_ok=True)
+        fileoperations.zip_up_folder(
+            upload_target_dir,
+            source_bundle_zip
+        )
+    else:
+        raise InvalidOptionsError(strings['deploy.archivemustbedirirzip'])
+    return source_bundle_zip

--- a/ebcli/lib/s3.py
+++ b/ebcli/lib/s3.py
@@ -115,10 +115,11 @@ def delete_objects(bucket, keys):
     return result
 
 
-def upload_workspace_version(bucket, key, file_path, workspace_type='Application'):
+def upload_workspace_version(bucket, key, file_path, workspace_type='Application', relative_to_project_root=True):
     cwd = os.getcwd()
     try:
-        fileoperations.ProjectRoot.traverse()
+        if relative_to_project_root:
+            fileoperations.ProjectRoot.traverse()
         size = os.path.getsize(file_path)
     except OSError as err:
         if err.errno == 2:
@@ -144,8 +145,8 @@ def upload_workspace_version(bucket, key, file_path, workspace_type='Application
     return result
 
 
-def upload_application_version(bucket, key, file_path):
-    upload_workspace_version(bucket, key, file_path, 'Application')
+def upload_application_version(bucket, key, file_path, relative_to_project_root=True):
+    upload_workspace_version(bucket, key, file_path, 'Application', relative_to_project_root=relative_to_project_root)
 
 
 def upload_platform_version(bucket, key, file_path):

--- a/ebcli/resources/strings.py
+++ b/ebcli/resources/strings.py
@@ -260,8 +260,7 @@ To get started enter "eb platform init". Then enter "eb platform create".""",
                           'Tags may only contain letters, numbers, and the following '
                           'symbols: / _ . : + = - @',
     'tags.max': 'Elastic Beanstalk supports a maximum of 50 tags.',
-    'deploy.invalidoptions': 'You cannot use the "--version" option with either the "--message" '
-                             'or "--label" option.',
+
     'init.getvarsfromoldeb': 'You previous used an earlier version of eb. Getting options from '
                              '.elasticbeanstalk/config.\n'
                              'Credentials will now be stored in ~/.aws/config',
@@ -324,12 +323,22 @@ To get started enter "eb platform init". Then enter "eb platform create".""",
     'region.china.credentials':
         'To use the China (Beijing) region, account credentials unique to the '
         'China (Beijing) region must be used.',
+
     'deploy.notadirectory': 'The directory {module} does not exist.',
     'deploy.modulemissingenvyaml':
         'All specified modules require an env.yaml file.\n'
         'The following modules are missing this file: {modules}',
     'deploy.noenvname':
         'No environment name was specified in env.yaml for module {module}. Unable to deploy.',
+    'deploy.invalidoptions': 'You cannot use the "--version" option with either the "--message" '
+                        'or "--label" option.',
+    'deploy.archivewithoutregion': 'You cannot use the "--archive" option without the "--region" option.',
+    'deploy.archivewithoutenvname': 'You cannot use the "--archive" option without the environment name.',
+    'deploy.archivewithversion': 'You cannot use the "--archive" option with the "--version" option for environment updates. '
+                                'These are mutually exclusive methods for specifying application code.',
+    'deploy.archivewithsource': 'You cannot use the "--archive" option with the "--source" option for environment updates. '
+                               'These are mutually exclusive methods for specifying application code.',
+    'deploy.archivemustbedirirzip': 'The "--archive" option requires a directory or ZIP file as an argument.',
     'compose.noenvyaml':
         'The module {module} does not contain an env.yaml file. This module will be skipped.',
     'compose.novalidmodules': 'No valid modules were found. No environments will be created.',
@@ -814,6 +823,7 @@ flag_text = {
     'deploy.group_suffix': 'group suffix',
     'deploy.source': 'source of code to deploy directly; example source_location/repo/branch',
     'deploy.process': 'enable preprocessing of the application version',
+    'deploy.archive': 'directory or ZIP file containing application version source code',
 
     'platformevents.version': 'version to retrieve events for',
     'events.follow': 'wait and continue to print events as they come',

--- a/tests/unit/controllers/test_deploy.py
+++ b/tests/unit/controllers/test_deploy.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import os
 import shutil
+import zipfile
+from unittest.mock import MagicMock
 
 import mock
 import unittest
@@ -21,6 +23,7 @@ from ebcli.core.ebcore import EB
 from ebcli.core import fileoperations
 from ebcli.objects.environment import Environment
 from ebcli.objects.platform import PlatformVersion
+from ebcli.objects.exceptions import InvalidOptionsError, NotInitializedError
 
 
 class TestDeploy(unittest.TestCase):
@@ -142,7 +145,8 @@ class TestDeployNormal(TestDeploy):
             process_app_versions=False,
             source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -174,7 +178,8 @@ class TestDeployNormal(TestDeploy):
             process_app_versions=False,
             source=None,
             staged=False,
-            timeout=0
+            timeout=0,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -204,9 +209,10 @@ class TestDeployNormal(TestDeploy):
             None,
             group_name=None,
             process_app_versions=False,
-            source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -242,9 +248,10 @@ class TestDeployNormal(TestDeploy):
             'This is my message',
             group_name=None,
             process_app_versions=False,
-            source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -283,7 +290,8 @@ class TestDeployNormal(TestDeploy):
             process_app_versions=True,
             source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -320,9 +328,10 @@ class TestDeployNormal(TestDeploy):
             'This is my message',
             group_name=None,
             process_app_versions=True,
-            source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -359,7 +368,8 @@ class TestDeployNormal(TestDeploy):
             process_app_versions=False,
             source=None,
             staged=False,
-            timeout=None
+            timeout=None,
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -394,9 +404,10 @@ class TestDeployNormal(TestDeploy):
             None,
             group_name=None,
             process_app_versions=False,
-            source='codecommit/my-repository/my-branch',
             staged=False,
-            timeout=None
+            timeout=None,
+            source='codecommit/my-repository/my-branch',
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -431,9 +442,10 @@ class TestDeployNormal(TestDeploy):
             None,
             group_name=None,
             process_app_versions=False,
-            source='codecommit/my-repository/my-branch/feature',
             staged=False,
-            timeout=None
+            timeout=None,
+            source='codecommit/my-repository/my-branch/feature',
+            source_bundle=None
         )
 
     @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
@@ -471,11 +483,81 @@ class TestDeployNormal(TestDeploy):
             process_app_versions=True,
             source=None,
             staged=True,
-            timeout=None
+            timeout=None,
+            source_bundle=None
         )
 
+    @mock.patch('ebcli.controllers.deploy.elasticbeanstalk.get_environment')
+    @mock.patch('ebcli.controllers.deploy._check_env_lifecycle_state')
+    @mock.patch('ebcli.controllers.deploy.deployops.deploy')
+    @mock.patch('ebcli.controllers.deploy.get_or_create_source_bundle')
+    def test_deploy_with_archive(
+            self,
+            get_source_bundle_mock,
+            deploy_mock,
+            _check_env_lifecycle_state_mock,
+            get_environment_mock,
+    ):
+        get_source_bundle_mock.return_value = 'path/to/generated/archive.zip'
+        environment_mock = MagicMock()
+        environment_mock.app_name = "my-application"
+        get_environment_mock.return_value = environment_mock
 
-class TestMultipleAppDeploy(unittest.TestCase):
+        app = EB(
+            argv=[
+                'deploy',
+                'environment-1',
+                '--archive', 'my-source-directory',
+                '--region', 'us-east-1'
+            ]
+        )
+        app.setup()
+        app.run()
+
+        _check_env_lifecycle_state_mock.assert_called_once_with('environment-1')
+        get_source_bundle_mock.assert_called_once_with(archive='my-source-directory', label=None)
+        deploy_mock.assert_called_with(
+            'my-application',
+            'environment-1',
+            None,
+            'archive.zip',
+            None,
+            group_name=None,
+            process_app_versions=False,
+            source=None,
+            staged=False,
+            timeout=None,
+            source_bundle='path/to/generated/archive.zip'
+        )
+
+    def test_deploy_with_archive__fails_without_environment_name(self):
+        app = EB(
+            argv=[
+                'deploy',
+                '--archive', 'my-source-directory',
+                '--region', 'us-east-1'
+            ]
+        )
+        app.setup()
+        try:
+            app.run()
+        except InvalidOptionsError:
+            pass
+
+    def test_deploy_with_archive__fails_without_region_name(self):
+        app = EB(
+            argv=[
+                'deploy',
+                'environment-1',
+                '--archive', 'my-source-directory',
+            ]
+        )
+        app.setup()
+        try:
+            app.run()
+        except InvalidOptionsError:
+            pass
+
     platform = PlatformVersion(
         'arn:aws:elasticbeanstalk:us-west-2::platform/PHP 7.1 running on 64bit Amazon Linux/2.6.5'
     )
@@ -490,6 +572,198 @@ class TestMultipleAppDeploy(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.root_dir)
         shutil.rmtree('testDir')
+
+
+class TestGetOrCreateSourceBundle(unittest.TestCase):
+    platform = PlatformVersion(
+        'arn:aws:elasticbeanstalk:us-west-2::platform/PHP 7.1 running on 64bit Amazon Linux/2.6.5'
+    )
+    
+    def setUp(self):
+        self.root_dir = os.getcwd()
+        if not os.path.exists('testDir'):
+            os.mkdir('testDir')
+
+        os.chdir('testDir')
+        
+        # Create test files and directories
+        if not os.path.exists('source_dir'):
+            os.mkdir('source_dir')
+        
+        with open(os.path.join('source_dir', 'test_file.txt'), 'w') as f:
+            f.write('test content')
+            
+        # Create a test zip file
+        self.test_zip_path = os.path.join(os.getcwd(), 'test_archive.zip')
+        with zipfile.ZipFile(self.test_zip_path, 'w') as test_zip:
+            test_zip.writestr('test_file.txt', 'test content')
+
+    def tearDown(self):
+        os.chdir(self.root_dir)
+        shutil.rmtree('testDir')
+        
+    def create_config_file_in(self, path):
+        original_dir = os.getcwd()
+        os.chdir(path)
+        fileoperations.create_config_file(
+            'my-application',
+            'us-west-2',
+            self.platform.name
+        )
+        os.chdir(original_dir)
+
+    @mock.patch('ebcli.controllers.deploy.zipfile.is_zipfile')
+    def test_get_or_create_source_bundle_with_zip_file(self, is_zipfile_mock):
+        # Setup
+        is_zipfile_mock.return_value = True
+        archive_path = 'test_archive.zip'
+        
+        # Execute
+        result = deploy.get_or_create_source_bundle(archive=archive_path)
+        
+        # Verify
+        is_zipfile_mock.assert_called_once_with(archive_path)
+        self.assertEqual(archive_path, result)
+
+    @mock.patch('ebcli.controllers.deploy.zipfile.is_zipfile')
+    @mock.patch('ebcli.controllers.deploy.path.isdir')
+    def test_get_or_create_source_bundle_with_invalid_input(self, isdir_mock, is_zipfile_mock):
+        # Setup
+        is_zipfile_mock.return_value = False
+        isdir_mock.return_value = False
+        archive_path = 'non_existent_path'
+        
+        # Execute and verify
+        with self.assertRaises(InvalidOptionsError) as context:
+            deploy.get_or_create_source_bundle(archive=archive_path)
+        
+        self.assertIn(
+            'The "--archive" option requires a directory or ZIP file as an argument.',
+            str(context.exception)
+        )
+        is_zipfile_mock.assert_called_once_with(archive_path)
+        isdir_mock.assert_called_once_with(archive_path)
+
+    @mock.patch('ebcli.controllers.deploy.zipfile.is_zipfile')
+    @mock.patch('ebcli.controllers.deploy.path.isdir')
+    @mock.patch('ebcli.controllers.deploy.datetime')
+    @mock.patch('ebcli.controllers.deploy.fileoperations.zip_up_folder')
+    @mock.patch('ebcli.controllers.deploy.makedirs')
+    @mock.patch('ebcli.controllers.deploy.path.expanduser')
+    def test_get_or_create_source_bundle_with_directory(
+            self,
+            expanduser_mock,
+            makedirs_mock,
+            zip_up_folder_mock,
+            datetime_mock,
+            isdir_mock,
+            is_zipfile_mock
+    ):
+        # Setup
+        is_zipfile_mock.return_value = False
+        isdir_mock.return_value = True
+        expanduser_mock.return_value = '/home/user'
+        
+        # Mock datetime to return a fixed timestamp
+        datetime_mock.datetime.now.return_value.timestamp.return_value = '1712175524.123456'
+        datetime_mock.UTC = mock.MagicMock()
+        
+        archive_path = 'source_dir'
+        expected_zip_path = os.path.join(
+            '/home/user',
+            '.ebartifacts',
+            'archives',
+            'archives-1712175524.123456.zip'
+        )
+        
+        # Execute
+        result = deploy.get_or_create_source_bundle(archive=archive_path)
+        
+        # Verify
+        is_zipfile_mock.assert_called_once_with(archive_path)
+        isdir_mock.assert_called_once_with(archive_path)
+        makedirs_mock.assert_called_once_with(
+            os.path.join('/home/user', '.ebartifacts', 'archives'),
+            exist_ok=True
+        )
+        zip_up_folder_mock.assert_called_once_with(archive_path, expected_zip_path)
+        self.assertEqual(expected_zip_path, result)
+
+    @mock.patch('ebcli.controllers.deploy.zipfile.is_zipfile')
+    @mock.patch('ebcli.controllers.deploy.path.isdir')
+    @mock.patch('ebcli.controllers.deploy.datetime')
+    @mock.patch('ebcli.controllers.deploy.fileoperations.zip_up_folder')
+    @mock.patch('ebcli.controllers.deploy.makedirs')
+    @mock.patch('ebcli.controllers.deploy.path.expanduser')
+    def test_get_or_create_source_bundle_with_directory_and_label(
+            self,
+            expanduser_mock,
+            makedirs_mock,
+            zip_up_folder_mock,
+            datetime_mock,
+            isdir_mock,
+            is_zipfile_mock
+    ):
+        # Setup
+        is_zipfile_mock.return_value = False
+        isdir_mock.return_value = True
+        expanduser_mock.return_value = '/home/user'
+        
+        archive_path = 'source_dir'
+        label = 'custom-label'
+        expected_zip_path = os.path.join(
+            '/home/user',
+            '.ebartifacts',
+            'archives',
+            'custom-label.zip'
+        )
+        
+        # Execute
+        result = deploy.get_or_create_source_bundle(archive=archive_path, label=label)
+        
+        # Verify
+        is_zipfile_mock.assert_called_once_with(archive_path)
+        isdir_mock.assert_called_once_with(archive_path)
+        makedirs_mock.assert_called_once_with(
+            os.path.join('/home/user', '.ebartifacts', 'archives'),
+            exist_ok=True
+        )
+        zip_up_folder_mock.assert_called_once_with(archive_path, expected_zip_path)
+        self.assertEqual(expected_zip_path, result)
+
+    @mock.patch('ebcli.controllers.deploy.zipfile.is_zipfile')
+    @mock.patch('ebcli.controllers.deploy.path.isdir')
+    @mock.patch('ebcli.controllers.deploy.datetime')
+    @mock.patch('ebcli.controllers.deploy.fileoperations.zip_up_folder')
+    @mock.patch('ebcli.controllers.deploy.makedirs')
+    def test_get_source_bundle_from_archive_creates_directories(
+            self,
+            makedirs_mock,
+            zip_up_folder_mock,
+            datetime_mock,
+            isdir_mock,
+            is_zipfile_mock
+    ):
+        # Setup
+        is_zipfile_mock.return_value = False
+        isdir_mock.return_value = True
+        
+        # Mock datetime to return a fixed timestamp
+        mock_datetime = mock.MagicMock()
+        mock_datetime.now.return_value.timestamp.return_value = '1712175524.123456'
+        datetime_mock.now.return_value = mock_datetime
+        datetime_mock.UTC = mock.MagicMock()
+        
+        archive_path = 'source_dir'
+        
+        # Execute
+        deploy.get_or_create_source_bundle(archive=archive_path)
+        
+        # Verify
+        makedirs_mock.assert_called_once_with(
+            os.path.join(os.path.expanduser('~'), '.ebartifacts', 'archives'),
+            exist_ok=True
+        )
 
     @mock.patch('ebcli.controllers.deploy.io.log_error')
     def test_multiple_modules__none_of_the_specified_modules_actually_exists(

--- a/tests/unit/lib/test_s3.py
+++ b/tests/unit/lib/test_s3.py
@@ -332,7 +332,7 @@ class TestS3(unittest.TestCase):
     ):
         s3.upload_application_version('bucket', 'key', 'file/path.py')
 
-        upload_workspace_version_mock.assert_called_once_with('bucket', 'key', 'file/path.py', 'Application')
+        upload_workspace_version_mock.assert_called_once_with('bucket', 'key', 'file/path.py', 'Application', relative_to_project_root=True)
 
     @mock.patch('ebcli.lib.s3.upload_workspace_version')
     def test_upload_platform_version(

--- a/tests/unit/lib/test_s3_upload_workspace.py
+++ b/tests/unit/lib/test_s3_upload_workspace.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+import unittest
+import mock
+
+from ebcli.core import fileoperations
+from ebcli.lib import s3
+
+
+class TestUploadWorkspaceVersion(unittest.TestCase):
+    def setUp(self):
+        self.root_dir = os.getcwd()
+        if os.path.exists('testDir'):
+            shutil.rmtree('testDir')
+        os.mkdir('testDir')
+        os.chdir('testDir')
+
+    def tearDown(self):
+        os.chdir(self.root_dir)
+        shutil.rmtree('testDir')
+
+    @mock.patch('ebcli.lib.s3.aws.make_api_call')
+    @mock.patch('ebcli.lib.s3.os.path.getsize')
+    @mock.patch('ebcli.lib.s3.simple_upload')
+    def test_upload_workspace_version_with_relative_to_project_root_false(
+            self,
+            mock_simple_upload,
+            mock_getsize,
+            mock_make_api_call
+    ):
+        # Setup
+        fileoperations.create_config_file(
+            'my-application',
+            'us-west-2',
+            'php-7.1'
+        )
+        mock_getsize.return_value = 7340031  # Small enough for simple upload
+        mock_simple_upload.return_value = 'upload_result'
+        
+        # Create a test file
+        with open('test_file.txt', 'w') as f:
+            f.write('test content')
+        
+        # Call the function with relative_to_project_root=False
+        result = s3.upload_workspace_version(
+            'bucket', 
+            'key', 
+            'test_file.txt', 
+            workspace_type='Application',
+            relative_to_project_root=False
+        )
+        
+        # Verify
+        self.assertEqual('upload_result', result)
+        self.assertEqual(os.getcwd(), os.path.join(self.root_dir, 'testDir'))  # Should not change directory
+        mock_simple_upload.assert_called_once_with('bucket', 'key', 'test_file.txt')
+        
+    @mock.patch('ebcli.lib.s3.aws.make_api_call')
+    @mock.patch('ebcli.lib.s3.os.path.getsize')
+    @mock.patch('ebcli.lib.s3.simple_upload')
+    @mock.patch('ebcli.lib.s3.fileoperations.ProjectRoot.traverse')
+    def test_upload_workspace_version_with_relative_to_project_root_true(
+            self,
+            mock_traverse,
+            mock_simple_upload,
+            mock_getsize,
+            mock_make_api_call
+    ):
+        # Setup
+        fileoperations.create_config_file(
+            'my-application',
+            'us-west-2',
+            'php-7.1'
+        )
+        mock_getsize.return_value = 7340031  # Small enough for simple upload
+        mock_simple_upload.return_value = 'upload_result'
+        
+        # Create a test file
+        with open('test_file.txt', 'w') as f:
+            f.write('test content')
+        
+        # Call the function with default relative_to_project_root=True
+        result = s3.upload_workspace_version(
+            'bucket', 
+            'key', 
+            'test_file.txt', 
+            workspace_type='Application'
+        )
+        
+        # Verify
+        self.assertEqual('upload_result', result)
+        mock_traverse.assert_called()
+        mock_simple_upload.assert_called_once_with('bucket', 'key', 'test_file.txt')

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -1077,7 +1077,8 @@ class TestCommonOperations(unittest.TestCase):
             's3-bucket',
             's3-key',
             False,
-            build_config=None
+            build_config=None,
+            relative_to_project_root=True,
         )
 
     @mock.patch('ebcli.operations.commonops.fileoperations.ProjectRoot.traverse')
@@ -1138,7 +1139,8 @@ class TestCommonOperations(unittest.TestCase):
             's3-bucket',
             'my-application/version-label',
             False,
-            build_config=None
+            build_config=None,
+            relative_to_project_root=True,
         )
 
     @mock.patch('ebcli.operations.commonops.fileoperations.ProjectRoot.traverse')
@@ -1194,7 +1196,8 @@ class TestCommonOperations(unittest.TestCase):
             's3-bucket',
             'my-application/version-label.zip',
             False,
-            build_config=None
+            build_config=None,
+            relative_to_project_root=True,
         )
 
     @mock.patch('ebcli.operations.commonops.fileoperations.ProjectRoot.traverse')
@@ -1254,7 +1257,8 @@ class TestCommonOperations(unittest.TestCase):
             's3-bucket',
             'my-application/version-label',
             False,
-            build_config=None
+            build_config=None,
+            relative_to_project_root=True,
         )
 
     @mock.patch('ebcli.operations.commonops.fileoperations.ProjectRoot.traverse')
@@ -1295,7 +1299,7 @@ class TestCommonOperations(unittest.TestCase):
                 label='my-version-label',
                 message='message ' * 50,
                 process=True,
-                build_config=build_config_mock
+                build_config=build_config_mock,
             )
         )
 
@@ -1308,7 +1312,8 @@ class TestCommonOperations(unittest.TestCase):
             's3-bucket',
             's3-key',
             True,
-            build_config=build_config_mock
+            build_config=build_config_mock,
+            relative_to_project_root=True,
         )
 
     @mock.patch('ebcli.operations.commonops.fileoperations.ProjectRoot.traverse')

--- a/tests/unit/operations/test_deployops.py
+++ b/tests/unit/operations/test_deployops.py
@@ -174,3 +174,125 @@ class TestDeployOperations(unittest.TestCase):
             env_name='ebcli-env',
             timeout_in_minutes=5
         )
+        
+    @mock.patch('ebcli.operations.deployops.elasticbeanstalk')
+    @mock.patch('ebcli.operations.deployops.commonops')
+    @mock.patch('ebcli.operations.deployops.gitops')
+    @mock.patch('ebcli.operations.deployops.aws')
+    @mock.patch('ebcli.operations.deployops.fileoperations')
+    @mock.patch('ebcli.operations.deployops.io')
+    def test_deploy_with_zip_file(self, mock_io, mock_fileops, mock_aws, mock_gitops, mock_commonops, mock_beanstalk):
+        # Setup
+        mock_aws.get_region_name.return_value = 'us-east-1'
+        mock_fileops.build_spec_exists.return_value = False
+        mock_gitops.git_management_enabled.return_value = False
+        mock_commonops.handle_upload_target.return_value = self.app_version_name
+        mock_beanstalk.update_env_application_version.return_value = self.request_id
+        source_bundle_path = '/path/to/application.zip'
+
+        # Call the function with source_bundle parameter
+        deployops.deploy(self.app_name, self.env_name, None, None, self.description, source_bundle=source_bundle_path)
+
+        # Verify the correct calls were made
+        mock_commonops.handle_upload_target.assert_called_with(
+            self.app_name,
+            None,
+            None,
+            None,
+            source_bundle_path,
+            None,
+            self.description,
+            False,
+            None,
+            relative_to_project_root=False
+        )
+        mock_beanstalk.update_env_application_version.assert_called_with(self.env_name, self.app_version_name, None)
+        mock_commonops.wait_for_success_events.assert_called_with(
+            self.request_id,
+            can_abort=True,
+            env_name='ebcli-env',
+            timeout_in_minutes=5
+        )
+        
+    @mock.patch('ebcli.operations.deployops.elasticbeanstalk')
+    @mock.patch('ebcli.operations.deployops.commonops')
+    @mock.patch('ebcli.operations.deployops.aws')
+    @mock.patch('ebcli.operations.deployops.fileoperations')
+    @mock.patch('ebcli.operations.deployops.io')
+    def test_deploy_with_source_bundle(self, mock_io, mock_fileops, mock_aws, mock_commonops, mock_beanstalk):
+        # Setup
+        mock_aws.get_region_name.return_value = 'us-east-1'
+        mock_fileops.build_spec_exists.return_value = False
+        mock_commonops.handle_upload_target.return_value = self.app_version_name
+        mock_beanstalk.update_env_application_version.return_value = self.request_id
+        source_bundle_path = '/path/to/application.zip'
+        label = 'my-label'
+
+        # Call the function with source_bundle parameter
+        deployops.deploy(self.app_name, self.env_name, None, label, self.description, source_bundle=source_bundle_path)
+
+        # Verify the correct calls were made
+        mock_commonops.handle_upload_target.assert_called_with(
+            self.app_name,
+            None,
+            None,
+            label,
+            source_bundle_path,
+            label,
+            self.description,
+            False,
+            None,
+            relative_to_project_root=False
+        )
+        mock_beanstalk.update_env_application_version.assert_called_with(self.env_name, self.app_version_name, None)
+        mock_commonops.wait_for_success_events.assert_called_with(
+            self.request_id,
+            can_abort=True,
+            env_name='ebcli-env',
+            timeout_in_minutes=5
+        )
+        
+    @mock.patch('ebcli.operations.deployops.elasticbeanstalk')
+    @mock.patch('ebcli.operations.deployops.commonops')
+    @mock.patch('ebcli.operations.deployops.aws')
+    @mock.patch('ebcli.operations.deployops.fileoperations')
+    @mock.patch('ebcli.operations.deployops.buildspecops')
+    @mock.patch('ebcli.operations.deployops.io')
+    def test_deploy_with_source_bundle_and_build_config(
+            self, 
+            mock_io, 
+            mock_buildspecops, 
+            mock_fileops, 
+            mock_aws, 
+            mock_commonops, 
+            mock_beanstalk
+    ):
+        # Setup
+        mock_aws.get_region_name.return_value = 'us-east-1'
+        mock_fileops.build_spec_exists.return_value = True
+        build_config = self.build_config
+        mock_fileops.get_build_configuration.return_value = build_config
+        mock_commonops.handle_upload_target.return_value = self.app_version_name
+        mock_beanstalk.update_env_application_version.return_value = self.request_id
+        source_bundle_path = '/path/to/application.zip'
+        label = 'my-label'
+
+        # Call the function with source_bundle parameter
+        deployops.deploy(self.app_name, self.env_name, None, label, self.description, source_bundle=source_bundle_path)
+
+        # Verify the correct calls were made
+        mock_commonops.handle_upload_target.assert_called_with(
+            self.app_name,
+            None,
+            None,
+            label,
+            source_bundle_path,
+            label,
+            self.description,
+            False,
+            None,
+            relative_to_project_root=False
+        )
+        mock_beanstalk.update_env_application_version.assert_called_with(self.env_name, self.app_version_name, None)
+        # Verify buildspecops.stream_build_configuration_app_version_creation is NOT called with source_bundle
+        mock_buildspecops.stream_build_configuration_app_version_creation.assert_not_called()

--- a/tests/unit/operations/test_deployops_source_bundle.py
+++ b/tests/unit/operations/test_deployops_source_bundle.py
@@ -1,0 +1,134 @@
+import unittest
+import mock
+
+from ebcli.objects.buildconfiguration import BuildConfiguration
+from ebcli.operations import deployops
+
+
+class TestDeployWithSourceBundle(unittest.TestCase):
+    app_name = 'ebcli-app'
+    app_version_name = 'ebcli-app-version'
+    env_name = 'ebcli-env'
+    description = 'ebcli testing app'
+    s3_bucket = 'app_bucket'
+    s3_key = 'app_bucket_key'
+    request_id = 'foo-foo-foo-foo'
+
+    image = 'aws/codebuild/eb-java-8-amazonlinux-64:2.1.3'
+    compute_type = 'BUILD_GENERAL1_SMALL'
+    service_role = 'eb-test'
+    timeout = 60
+    build_config = BuildConfiguration(image=image, compute_type=compute_type,
+                                      service_role=service_role, timeout=timeout)
+
+    @mock.patch('ebcli.operations.deployops.elasticbeanstalk')
+    @mock.patch('ebcli.operations.deployops.commonops')
+    @mock.patch('ebcli.operations.deployops.aws')
+    @mock.patch('ebcli.operations.deployops.fileoperations')
+    @mock.patch('ebcli.operations.deployops.io')
+    def test_deploy_with_source_bundle(
+            self,
+            mock_io,
+            mock_fileops,
+            mock_aws,
+            mock_commonops,
+            mock_beanstalk
+    ):
+        # Setup
+        mock_aws.get_region_name.return_value = 'us-east-1'
+        mock_fileops.build_spec_exists.return_value = False
+        mock_commonops.handle_upload_target.return_value = self.app_version_name
+        mock_beanstalk.update_env_application_version.return_value = self.request_id
+        source_bundle_path = '/path/to/application.zip'
+        label = 'my-label'
+
+        # Call the function with source_bundle parameter
+        deployops.deploy(
+            self.app_name,
+            self.env_name,
+            None,
+            label,
+            self.description,
+            source_bundle=source_bundle_path
+        )
+
+        # Verify the correct calls were made
+        mock_commonops.handle_upload_target.assert_called_with(
+            self.app_name,
+            None,
+            None,
+            label,
+            source_bundle_path,
+            label,
+            self.description,
+            False,
+            None,
+            relative_to_project_root=False
+        )
+        mock_beanstalk.update_env_application_version.assert_called_with(
+            self.env_name,
+            self.app_version_name,
+            None
+        )
+        mock_commonops.wait_for_success_events.assert_called_with(
+            self.request_id,
+            can_abort=True,
+            env_name='ebcli-env',
+            timeout_in_minutes=5
+        )
+        
+    @mock.patch('ebcli.operations.deployops.elasticbeanstalk')
+    @mock.patch('ebcli.operations.deployops.commonops')
+    @mock.patch('ebcli.operations.deployops.aws')
+    @mock.patch('ebcli.operations.deployops.fileoperations')
+    @mock.patch('ebcli.operations.deployops.buildspecops')
+    @mock.patch('ebcli.operations.deployops.io')
+    def test_deploy_with_source_bundle_and_build_config(
+            self, 
+            mock_io, 
+            mock_buildspecops, 
+            mock_fileops, 
+            mock_aws, 
+            mock_commonops, 
+            mock_beanstalk
+    ):
+        # Setup
+        mock_aws.get_region_name.return_value = 'us-east-1'
+        mock_fileops.build_spec_exists.return_value = True
+        build_config = self.build_config
+        mock_fileops.get_build_configuration.return_value = build_config
+        mock_commonops.handle_upload_target.return_value = self.app_version_name
+        mock_beanstalk.update_env_application_version.return_value = self.request_id
+        source_bundle_path = '/path/to/application.zip'
+        label = 'my-label'
+
+        # Call the function with source_bundle parameter
+        deployops.deploy(
+            self.app_name,
+            self.env_name,
+            None,
+            label,
+            self.description,
+            source_bundle=source_bundle_path
+        )
+
+        # Verify the correct calls were made
+        mock_commonops.handle_upload_target.assert_called_with(
+            self.app_name,
+            None,
+            None,
+            label,
+            source_bundle_path,
+            label,
+            self.description,
+            False,
+            None,
+            relative_to_project_root=False
+        )
+        mock_beanstalk.update_env_application_version.assert_called_with(
+            self.env_name,
+            self.app_version_name,
+            None
+        )
+        # Verify buildspecops.stream_build_configuration_app_version_creation is NOT called with source_bundle
+        mock_buildspecops.stream_build_configuration_app_version_creation.assert_not_called()


### PR DESCRIPTION
### Issue #, if available:

Related to https://github.com/aws/aws-elastic-beanstalk-cli/issues/516. While the proposal in that issue is to allow passing in the application name, it is the environment name that makes more sense to pass in.

### Description of changes:

This commit adds support `eb deploy ... --archive <ZIP|dir>` so that customers can point to arbitrary directories/ZIP files to deploy to existing environments.  In the presence of the `--archive` argument, `eb deploy` will ignore the .elasticbeanstalk/config.yml file if it is present. If it is not present, it will operate in its absence. The `--archive` argument will accept directories or ZIP files. If the argument is a directory, `eb deploy` will ZIP the directory and save it in the `~/.ebartifacts/archives` directory. It will upload it to S3 and invoke EB::CreateApplicationVersion with the artifact. Like with the eb-deploy flow without `--archive`, it will proceed to perform an EB::UpdateEnvironment and wait for the update to complete.

One limitation of the current approach is that it requires the environment to already exist. It would be nice to have `eb deploy` issue an environment trigger based on the `eb create`'s sane defaults.

----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
