### PR TITLE
Provide a way to specify the environment name to use with 'eb init'

### DIFF
--- a/ebcli/controllers/initialize.py
+++ b/ebcli/controllers/initialize.py
@@ -52,6 +52,7 @@ class InitController(AbstractBaseController):
         arguments = [
             (['application_name'], dict(
                 help=flag_text['init.name'], nargs='?', default=[])),
+            (['-e', '--environment-name'], dict(help=flag_text['init.environment_name'])),
             (['-m', '--modules'], dict(help=flag_text['init.module'], nargs='*')),
             (['-p', '--platform'], dict(help=flag_text['init.platform'])),
             (['-k', '--keyname'], dict(help=flag_text['init.keyname'])),
@@ -74,6 +75,7 @@ class InitController(AbstractBaseController):
         platform = self.app.pargs.platform
         source = self.app.pargs.source
         app_name = self.app.pargs.application_name
+        env_name = self.app.pargs.environment_name
         modules = self.app.pargs.modules
         force_non_interactive = _customer_is_avoiding_interactive_flow(
             self.app.pargs)
@@ -98,7 +100,7 @@ class InitController(AbstractBaseController):
         region_name = commonops.set_region_for_application(interactive, region_name, force_non_interactive, platform)
         commonops.set_up_credentials(profile, region_name, interactive)
         app_name = get_app_name(app_name, interactive, force_non_interactive)
-        default_env = set_default_env(interactive, force_non_interactive)
+        default_env = env_name or set_default_env(interactive, force_non_interactive)
         tags = tagops.get_and_validate_tags(tags)
 
         platform_arn, keyname_of_existing_application = create_app_or_use_existing_one(app_name, default_env, tags)
@@ -111,7 +113,6 @@ class InitController(AbstractBaseController):
 
         prompt_codecommit = should_prompt_customer_to_opt_into_codecommit(
             force_non_interactive,
-            region_name,
             source
         )
         repository, branch = None, None
@@ -514,7 +515,6 @@ def establish_codecommit_repository_and_branch(repository, branch, source_contro
 
 def should_prompt_customer_to_opt_into_codecommit(
         force_non_interactive,
-        region_name,
         source
 ):
     source_location, repository, branch = utils.parse_source(source)
@@ -526,10 +526,8 @@ def should_prompt_customer_to_opt_into_codecommit(
             io.log_warning(strings['codecommit.badregion'])
         return False
     elif not fileoperations.is_git_directory_present():
-        io.echo(strings['codecommit.nosc'])
         return False
     elif not fileoperations.program_is_installed('git'):
-        io.echo(strings['codecommit.nosc'])
         return False
     elif directory_is_already_associated_with_a_branch():
         return False

--- a/ebcli/resources/strings.py
+++ b/ebcli/resources/strings.py
@@ -822,6 +822,7 @@ flag_text = {
     'init.platform': 'default Platform',
     'init.keyname': 'default EC2 key name',
     'init.interactive': 'force interactive mode',
+    'init.environment_name': 'default environment name',
 
     'platformcreate.instanceprofile': 'the instance profile to use when creating AMIs '
                                       'for custom platforms',

--- a/tests/unit/controllers/test_init.py
+++ b/tests/unit/controllers/test_init.py
@@ -2031,14 +2031,13 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 True,
-                'us-west-2',
                 'codecommit/repository/branch'
             )
         )
 
     def test_should_prompt_customer_to_opt_into_codecommit__no_source(self):
         self.assertFalse(
-            initialize.should_prompt_customer_to_opt_into_codecommit(False, 'us-west-2', None)
+            initialize.should_prompt_customer_to_opt_into_codecommit(False, None)
         )
 
     @mock.patch('ebcli.controllers.initialize.codecommit.region_supported')
@@ -2051,7 +2050,6 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-10',
                 'codecommit/repository/branch'
             )
         )
@@ -2068,7 +2066,6 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-10',
                 'codecommit/repository/branch'
             )
         )
@@ -2077,10 +2074,8 @@ class TestInitModule(unittest.TestCase):
 
     @mock.patch('ebcli.controllers.initialize.codecommit.region_supported')
     @mock.patch('ebcli.controllers.initialize.fileoperations.is_git_directory_present')
-    @mock.patch('ebcli.controllers.initialize.io.echo')
     def test_should_prompt_customer_to_opt_into_codecommit__directory_is_not_git_inited(
             self,
-            echo_mock,
             is_git_directory_present_mock,
             region_supported_mock
     ):
@@ -2090,23 +2085,17 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-2',
                 'codecommit/repository/branch'
             )
         )
 
         region_supported_mock.assert_called_once_with()
-        echo_mock.assert_called_once_with(
-            'Cannot setup CodeCommit because there is no Source Control setup, continuing with initialization'
-        )
 
     @mock.patch('ebcli.controllers.initialize.codecommit.region_supported')
     @mock.patch('ebcli.controllers.initialize.fileoperations.is_git_directory_present')
     @mock.patch('ebcli.controllers.initialize.fileoperations.program_is_installed')
-    @mock.patch('ebcli.controllers.initialize.io.echo')
     def test_should_prompt_customer_to_opt_into_codecommit__git_not_installed(
             self,
-            echo_mock,
             program_is_installed_mock,
             is_git_directory_present_mock,
             region_supported_mock
@@ -2118,16 +2107,12 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-2',
                 'codecommit/repository/branch'
             )
         )
 
         region_supported_mock.assert_called_once_with()
         program_is_installed_mock.assert_called_once_with('git')
-        echo_mock.assert_called_once_with(
-            'Cannot setup CodeCommit because there is no Source Control setup, continuing with initialization'
-        )
 
     @mock.patch('ebcli.controllers.initialize.codecommit.region_supported')
     @mock.patch('ebcli.controllers.initialize.fileoperations.is_git_directory_present')
@@ -2150,7 +2135,6 @@ class TestInitModule(unittest.TestCase):
         self.assertFalse(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-2',
                 'codecommit/repository/branch'
             )
         )
@@ -2181,7 +2165,6 @@ class TestInitModule(unittest.TestCase):
         self.assertTrue(
             initialize.should_prompt_customer_to_opt_into_codecommit(
                 False,
-                'us-west-2',
                 'codecommit/repository/branch'
             )
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This commit provides a way to specify the environment name to use as the default environment for the workspace. This allows for a way to avoid executing the `eb use` command after initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
