### PR TITLE
Fix 3.8, 3.9 backwards incompatibility caused by use of datetime.UTC

### DIFF
--- a/ebcli/display/traditional.py
+++ b/ebcli/display/traditional.py
@@ -10,9 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from datetime import datetime, UTC
-import locale
-
 from botocore.compat import six
 from cement.utils.misc import minimal_logger
 
@@ -20,7 +17,7 @@ from ebcli.core import io
 from ebcli.display import term
 from ebcli.display.data_poller import DataPoller
 from ebcli.display.screen import Screen
-from ebcli.lib import ec2, elasticbeanstalk, elb, elbv2
+from ebcli.lib import ec2, elasticbeanstalk, elb, elbv2, utils
 from ebcli.resources import statics
 
 
@@ -149,4 +146,4 @@ class TraditionalHealthScreen(Screen):
 
 
 def _datetime_utcnow_wrapper():
-    return datetime.now(UTC)
+    return utils.datetime_utcnow()

--- a/ebcli/lib/utils.py
+++ b/ebcli/lib/utils.py
@@ -19,7 +19,7 @@ import string
 import sys
 import textwrap
 import time
-from datetime import datetime, UTC
+from datetime import datetime
 
 from dateutil import tz, parser
 
@@ -298,9 +298,9 @@ def prettydate(d):
     """
 
     if isinstance(d, float):
-        d = datetime.fromtimestamp(d, UTC)
+        d = fromutctimestamp(d)
 
-    diff = datetime.now(UTC) - d
+    diff = datetime_utcnow() - d
     s = diff.seconds
     if diff.days > 7 or diff.days < 0:
         return d.strftime('%d %b %y')
@@ -581,7 +581,19 @@ def sleep(sleep_time=5):
 
 
 def datetime_utcnow():
-    return datetime.now(UTC)
+    try:
+        from datetime import UTC
+        return datetime.now(UTC)
+    except ImportError:
+        return datetime.utcnow()
+
+
+def fromutctimestamp(d):
+    try:
+        from datetime import UTC
+        return datetime.fromtimestamp(d, UTC)
+    except ImportError:
+        return datetime.utcfromtimestamp(d)
 
 
 def prevent_throttling():

--- a/ebcli/operations/buildspecops.py
+++ b/ebcli/operations/buildspecops.py
@@ -13,10 +13,10 @@
 
 import time
 
-from datetime import datetime, timedelta, UTC
+from datetime import timedelta
 from cement.utils.misc import minimal_logger
 from ebcli.core import io
-from ebcli.lib import elasticbeanstalk, codebuild
+from ebcli.lib import elasticbeanstalk, codebuild, utils
 from ebcli.objects.exceptions import ServiceError, ValidationError
 
 from ebcli.resources.strings import strings
@@ -108,7 +108,7 @@ def wait_for_app_version_attribute(app_name, version_labels, timeout=5):
     versions_to_check = list(version_labels)
     found = dict.fromkeys(version_labels)
     failed = dict.fromkeys(version_labels)
-    start_time = datetime.now(UTC)
+    start_time = utils.datetime_utcnow()
     timediff = timedelta(minutes=timeout)
     while versions_to_check:
         if _timeout_reached(start_time, timediff):
@@ -151,4 +151,4 @@ def _sleep():
 
 
 def _timeout_reached(start_time, timediff):
-    return datetime.now(UTC) - start_time >= timediff
+    return utils.datetime_utcnow() - start_time >= timediff

--- a/ebcli/operations/commonops.py
+++ b/ebcli/operations/commonops.py
@@ -13,7 +13,7 @@
 import os
 import sys
 import time
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 import platform
 
 from ebcli.core.fileoperations import _marker
@@ -60,7 +60,7 @@ def wait_for_success_events(request_id, timeout_in_minutes=None,
     if timeout_in_minutes is None:
         timeout_in_minutes = 10
 
-    start = datetime.now(UTC)
+    start = utils.datetime_utcnow()
     timediff = timedelta(seconds=timeout_in_minutes * 60)
 
     last_time = start
@@ -187,18 +187,18 @@ def wait_for_compose_events(request_id, app_name, grouped_envs, timeout_in_minut
     if timeout_in_minutes is None:
         timeout_in_minutes = 15
 
-    start = datetime.now(UTC)
+    start = utils.datetime_utcnow()
     timediff = timedelta(seconds=timeout_in_minutes * 60)
 
     last_times = []
     events_matrix = []
     successes = []
 
-    last_time_compose = datetime.now(UTC)
+    last_time_compose = utils.datetime_utcnow()
     compose_events = []
 
     for i in range(len(grouped_envs)):
-        last_times.append(datetime.now(UTC))
+        last_times.append(utils.datetime_utcnow())
         events_matrix.append([])
         successes.append(False)
 
@@ -880,7 +880,7 @@ def wait_for_processed_app_versions(app_name, version_labels, timeout=5):
     for version in version_labels:
         processed[version] = False
         failed[version] = False
-    start_time = datetime.now(UTC)
+    start_time = utils.datetime_utcnow()
     timediff = timedelta(seconds=timeout * 60)
     while not all([(processed[version] or failed[version]) for version in versions_to_check]):
         if _timeout_reached(start_time, timediff):
@@ -1096,4 +1096,4 @@ def _sleep(sleep_time):
 
 
 def _timeout_reached(start, timediff):
-    return (datetime.now(UTC) - start) >= timediff
+    return (utils.datetime_utcnow() - start) >= timediff

--- a/ebcli/operations/logsops.py
+++ b/ebcli/operations/logsops.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import calendar
-from datetime import datetime, UTC
+from datetime import datetime
 import os
 import threading
 import time
@@ -952,7 +952,7 @@ def _timestamped_directory_name():
 
 
 def _updated_start_time():
-    return calendar.timegm(datetime.now(UTC).timetuple()) * 1000
+    return calendar.timegm(utils.datetime_utcnow().timetuple()) * 1000
 
 
 def _updated_instance_id_list(instance_id_list, instance_id):

--- a/tests/unit/containers/test_log.py
+++ b/tests/unit/containers/test_log.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from datetime import datetime, UTC
+from datetime import datetime
 import os
 import shutil
 import sys
@@ -32,7 +32,7 @@ HOST_LOG = os.path.join('.elasticbeanstalk', 'logs', 'local', '1234567')
 CONTAINER_LOG = os.path.join('var', 'log')
 LOG_VOLUME_MAP = {HOST_LOG: CONTAINER_LOG}
 DOCKERRUN = {dockerrun.LOGGING_KEY: CONTAINER_LOG}
-MOCK_DATETIME = datetime(2015, 3, 18, 13, 33, 30, 254552, tzinfo=UTC)
+MOCK_DATETIME = datetime(2015, 3, 18, 13, 33, 30, 254552)
 EXPECTED_DATETIME_STR = '150318_133330254552'
 EXPECTED_HOST_LOG_PATH = os.path.join(ROOT_LOG_DIR, EXPECTED_DATETIME_STR)
 EXPECTED_LOGDIR_PATH = '.'

--- a/tests/unit/lib/test_utils.py
+++ b/tests/unit/lib/test_utils.py
@@ -240,7 +240,7 @@ class TestUtils(TestCase):
         utils.sleep(sleep_time=0)
 
     def test_datetime_utcnow(self):
-        now = datetime.datetime.now(datetime.UTC)
+        now = utils.datetime_utcnow()
         a_little_later = utils.datetime_utcnow()
         very_small_difference = datetime.timedelta(seconds=0.001)
         self.assertTrue(

--- a/tests/unit/operations/test_commonops.py
+++ b/tests/unit/operations/test_commonops.py
@@ -12,9 +12,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 import os
-import sys
 import shutil
 
 from dateutil import tz
@@ -28,6 +27,7 @@ from ebcli.objects.event import Event
 from ebcli.objects.environment import Environment
 from ebcli.objects.region import Region
 from ebcli.operations import commonops
+from ebcli.lib import utils
 from ebcli.lib.aws import InvalidParameterValueError
 from ebcli.objects.buildconfiguration import BuildConfiguration
 from ebcli.resources.strings import strings, responses
@@ -592,7 +592,7 @@ class TestCommonOperations(unittest.TestCase):
     def test_timeout_reached(self):
         self.assertTrue(
             commonops._timeout_reached(
-                datetime.now(UTC) - timedelta(minutes=5),
+                utils.datetime_utcnow() - timedelta(minutes=5),
                 timedelta(seconds=300)
             )
         )
@@ -600,7 +600,7 @@ class TestCommonOperations(unittest.TestCase):
     def test_timeout_reached__false(self):
         self.assertFalse(
             commonops._timeout_reached(
-                datetime.now(UTC) - timedelta(minutes=5),
+                utils.datetime_utcnow() - timedelta(minutes=5),
                 timedelta(seconds=301)
             )
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes breakages introduced to the master branch by a previous PR merge that removed usages of `datetime.UTC` which was introduced only in Python 3.11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
