### PR TITLE
Fix issue with eb health --refresh on Windows

### DIFF
--- a/ebcli/display/term.py
+++ b/ebcli/display/term.py
@@ -251,11 +251,11 @@ class WindowsTerminal(object):
 
             def __enter__(self):
                 self.saved_position = self.term._get_cursor_pos()
-                print(self.term.move(y, x))
+                print(self.term.move(y, x), end='')
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 # Return cursor state
-                print(self.term.move(self.saved_position[1], self.saved_position[0]))
+                print(self.term.move(self.saved_position[1], self.saved_position[0]), end='')
 
         return TermLocation(self)
 


### PR DESCRIPTION
*Description of changes:*

Fix issue with eb health --refresh on Windows where the health screen does not load properly and it refreshes frequently. By default, Python's print() function adds a newline character (\n) at the end of the output. The end='' parameter overrides this behavior, telling Python not to add a newline. In Windows this causes a carriage return which resets the cursor location from the location that we saved. As a result, the EB CLI is not able to resume updating and this results in flickering as it reset the cursor position.

*Testing:*
Tested command on Windows instance, observed properly terminal formatting with refresh occurring at expected interval and no flickering. Test on Mac OS as well and existing behavior is preserved.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
