### PR TITLE
Set explicit dependency on packaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 --------------------
+3.22.1 (2025-04-17)
+--------------------
+- Added dependency on packaging `>=24.2,<25.0`
+
+--------------------
 3.22.0 (2025-04-14)
 --------------------
 - Added `--archive` argument through `eb deploy` to deploy prepackaged zip files to environments

--- a/ebcli/__init__.py
+++ b/ebcli/__init__.py
@@ -11,4 +11,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-__version__ = '3.22.0'
+__version__ = '3.22.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ termcolor>=2.4.0,<3
 wcwidth>=0.2.13,<0.3
 PyYAML>=5.3.1,<6.1 # use the same range that 'aws-cli' uses
 urllib3>=1.26.5,<2
+packaging>=24.2,<25.0


### PR DESCRIPTION
*Issue #, if available:*

See https://github.com/aws/aws-elastic-beanstalk-cli/issues/541.

*Description of changes:*

We deprecated usage of pkg_resources in favour of packaging but did not add explicit dependency on packaging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
