### PR TITLE
Prevent execution of 'eb migrate' on non-Windows and fix info messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 --------------------
+3.23.1 (2025-04-18)
+--------------------
+- Handle `eb migrate` execution failures on non-Windows machines gracefully
+
+--------------------
 3.23 (2025-04-18)
 --------------------
 - Declared dependency on blessed for Windows, Linux and macOS

--- a/ebcli/__init__.py
+++ b/ebcli/__init__.py
@@ -11,4 +11,4 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-__version__ = '3.23'
+__version__ = '3.23.1'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Prevent execution of 'eb migrate' on non-Windows and fix info messages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
