### PR TITLE
Add EB Migrate Remote Execution Capability

### DIFF
--- a/ebcli/controllers/migrate_scripts/reinstate_iisstart_htm_default_document.ps1
+++ b/ebcli/controllers/migrate_scripts/reinstate_iisstart_htm_default_document.ps1
@@ -10,4 +10,13 @@ if (-not [Environment]::Is64BitProcess) {
     exit
 }
 
-Add-WebConfigurationProperty -Filter "system.webServer/defaultDocument/files" -Name "." -Value @{value='iisstart.htm'}
+# Check if iisstart.htm is already in the default document list
+$existingEntry = Get-WebConfigurationProperty -Filter "system.webServer/defaultDocument/files/add[@value='iisstart.htm']" -Name "." -ErrorAction SilentlyContinue
+
+# Only add if it doesn't already exist
+if ($existingEntry -eq $null) {
+    Add-WebConfigurationProperty -Filter "system.webServer/defaultDocument/files" -Name "." -Value @{value='iisstart.htm'}
+    Write-HostWithTimestamp "Added iisstart.htm to default documents"
+} else {
+    Write-HostWithTimestamp "iisstart.htm is already in default documents, skipping"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyYAML>=5.3.1,<6.1
 urllib3>=1.26.5,<2
 packaging>=24.2,<25.0
 blessed>=1.20.0
+fabric==3.2.2


### PR DESCRIPTION
*Description of changes:*
This change is to extend the existing eb migrate command's capabilities to allow for remote execution. It is now possible to install the eb cli on a bastion host and connect to the production machine, extract its IIS setup, and launch an environment all without installing anything on the production machine. This provides a safer, more managed and less invasive way for customers to migrate their IIS resources to Beanstalk.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
