### PR TITLE
Fix role policy support for AWS GovCloud

### DIFF
--- a/ebcli/operations/commonops.py
+++ b/ebcli/operations/commonops.py
@@ -964,7 +964,12 @@ def create_default_instance_profile(profile_name=iam_attributes.DEFAULT_ROLE_NAM
     """
     Create default elasticbeanstalk IAM profile and return its name.
     """
-    create_instance_profile(profile_name, iam_attributes.DEFAULT_ROLE_POLICIES)
+    region = aws.get_region_name()
+    if isinstance(region, str) and 'us-gov' in region:
+        policies = iam_attributes.DEFAULT_ROLE_POLICIES_US_GOV
+    else:
+        policies = iam_attributes.DEFAULT_ROLE_POLICIES
+    create_instance_profile(profile_name, policies)
     return profile_name
 
 

--- a/ebcli/resources/statics.py
+++ b/ebcli/resources/statics.py
@@ -41,6 +41,11 @@ class iam_attributes(object):
         'arn:aws:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker',
         'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
     ]
+    DEFAULT_ROLE_POLICIES_US_GOV = [
+        'arn:aws-us-gov:iam::aws:policy/AWSElasticBeanstalkWebTier',
+        'arn:aws-us-gov:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker',
+        'arn:aws-us-gov:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
+    ]
     DEFAULT_CUSTOM_PLATFORM_BUILDER_POLICIES = [
         'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier',
         'arn:aws:iam::aws:policy/AWSElasticBeanstalkCustomPlatformforEC2Role',


### PR DESCRIPTION
This resolves a "ServiceError - Invalid ARN partition" failure when running `eb create` on an AWS GovCloud account.

*Description of changes:*
AWS GovCloud stores its policies under a [separate partition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html#arns-syntax), `arn-us-gov`. For example, the `AWSElasticBeanstalkWebTier` policy ARN is `arn:aws-us-gov:iam::aws:policy/AWSElasticBeanstalkWebTier`.

![image](https://github.com/user-attachments/assets/c1798c5f-d5a6-4dbe-85cd-9bc04812e948)

Previously, when running an `eb create` I would receive a `ServiceError - Invalid ARN partition` message because of the incorrect policy name as it goes to attach the policy to the EC2 role. Adding a special case for regions like e.g. `us-gov-east-1` resolves the issue and the command completes successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
