### PR TITLE
Fix unlisted Windows dependencies

### DIFF
--- a/ebcli/controllers/migrate.py
+++ b/ebcli/controllers/migrate.py
@@ -26,7 +26,12 @@ import argparse
 from fabric import Connection
 import base64
 
-if sys.platform.startswith("win"):
+def is_supported() -> bool:
+    return (sys.platform.startswith("win")
+            and os.path.exists(r"C:\Windows\System32\inetsrv\Microsoft.Web.Administration.dll"))
+
+
+if is_supported():
     import winreg
     import clr
     import win32com.client
@@ -84,7 +89,7 @@ class MigrateExploreController(AbstractBaseController):
         stacked_type = "nested"
 
     def do_command(self):
-        if not sys.platform.startswith("win"):
+        if not is_supported():
             raise NotSupportedError("'eb migrate explore' is only supported on Windows")
         verbose = self.app.pargs.verbose
 
@@ -107,7 +112,7 @@ class MigrateCleanupController(AbstractBaseController):
         ]
 
     def do_command(self):
-        if not sys.platform.startswith("win"):
+        if not is_supported():
             raise NotSupportedError("'eb migrate cleanup' is only supported on Windows")
         force = self.app.pargs.force
         cleanup_previous_migration_artifacts(force, self.app.pargs.verbose)
@@ -364,7 +369,7 @@ class MigrateController(AbstractBaseController):
 
     def do_command(self):
         remote = self.app.pargs.remote
-        if not remote and not sys.platform.startswith("win"):
+        if not remote and not is_supported():
             raise NotSupportedError("'eb migrate' is only supported on Windows")
 
         verbose = self.app.pargs.verbose

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ urllib3>=1.26.5,<2
 packaging>=24.2,<25.0
 blessed>=1.20.0
 fabric==3.2.2
+pythonnet>=3.0.5,<4 ; platform_system=="Windows"

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,6 @@ extras_require = {
     ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==223',
 
 }
-if sys.platform.startswith('win'):
-    requires.append('pythonnet>=3.0.5,<4')
-
 
 setup_options = dict(
     name='awsebcli',

--- a/tests/unit/integration/test_migrate.py
+++ b/tests/unit/integration/test_migrate.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 import unittest
 import sys
 
-if sys.platform.startswith("win"):
+if sys.platform.startswith("win") and os.path.exists(r"C:\Windows\System32\inetsrv\Microsoft.Web.Administration.dll"):
     import clr
 
     clr.AddReference("System.Reflection")


### PR DESCRIPTION
*Issue #, if available:* #566


*Description of changes:*
* Move pythonnet dependency to requirements.txt, with environment marker (PEP 508)
* Require existence of Microsoft.Web.Administration.dll for eb migrate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
