### PR TITLE
Updating error message for IIS installation check in migrate

### DIFF
--- a/ebcli/controllers/migrate.py
+++ b/ebcli/controllers/migrate.py
@@ -90,7 +90,7 @@ class MigrateExploreController(AbstractBaseController):
 
     def do_command(self):
         if not is_supported():
-            raise NotSupportedError("'eb migrate explore' is only supported on Windows")
+            raise NotSupportedError("'eb migrate explore' is only supported on Windows with IIS installed")
         verbose = self.app.pargs.verbose
 
         if verbose:
@@ -113,7 +113,7 @@ class MigrateCleanupController(AbstractBaseController):
 
     def do_command(self):
         if not is_supported():
-            raise NotSupportedError("'eb migrate cleanup' is only supported on Windows")
+            raise NotSupportedError("'eb migrate cleanup' is only supported on Windows with IIS installed")
         force = self.app.pargs.force
         cleanup_previous_migration_artifacts(force, self.app.pargs.verbose)
 
@@ -370,7 +370,7 @@ class MigrateController(AbstractBaseController):
     def do_command(self):
         remote = self.app.pargs.remote
         if not remote and not is_supported():
-            raise NotSupportedError("'eb migrate' is only supported on Windows")
+            raise NotSupportedError("'eb migrate' is only supported on Windows with IIS installed")
 
         verbose = self.app.pargs.verbose
 

--- a/tests/unit/controllers/test_migrate.py
+++ b/tests/unit/controllers/test_migrate.py
@@ -33,7 +33,7 @@ from ebcli.controllers.migrate import (
 )
 
 
-@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows")
+@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows with IIS installed")
 class TestMigrateController(unittest.TestCase):
     """Tests for the migrate controller module."""
 
@@ -108,7 +108,7 @@ class TestMigrateController(unittest.TestCase):
         )
 
 
-@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows")
+@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows with IIS installed")
 class TestSortRulesBySpecificity(unittest.TestCase):
     """Tests for the _sort_rules_by_specificity function."""
 
@@ -267,7 +267,7 @@ class TestSortRulesBySpecificity(unittest.TestCase):
         self.assertEqual(multiple_hosts_rule, sorted_rules[2])
 
 
-@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows")
+@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows with IIS installed")
 class TestCreateAlbRules(unittest.TestCase):
     """Tests for the create_alb_rules function."""
 
@@ -519,7 +519,7 @@ class TestCreateAlbRules(unittest.TestCase):
         self.assertEqual(rules, [])  # Should ignore non-HTTP/HTTPS sites
 
 
-@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows")
+@skipIf(not sys.platform.startswith("win"), "`eb migrate` only supports Windows with IIS installed")
 class TestGetSiteConfigs(unittest.TestCase):
     """Tests for the get_site_configs function."""
 


### PR DESCRIPTION
Follow up on PR #567 
*Description of changes:*

- Updating error message to reflect IIS installation check.
- Updating migrate tests for the new error messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
