### PR TITLE
Fix 'occured' -> 'occurred' in exceptions, s3 upload error, and test assertion

### DIFF
--- a/ebcli/lib/s3.py
+++ b/ebcli/lib/s3.py
@@ -203,7 +203,7 @@ def multithreaded_upload(bucket, key, file_path):
         if not _all_parts_were_uploaded(etaglist, total_parts):
             LOG.debug('Uploaded {0} parts, but should have uploaded {1} parts.'
                       .format(len(etaglist), total_parts))
-            raise UploadError('An error occured while uploading Application Version. '
+            raise UploadError('An error occurred while uploading Application Version. '
                               'Use the --debug option for more information if the problem persists.')
         result = _make_api_call(
             'complete_multipart_upload',

--- a/ebcli/objects/exceptions.py
+++ b/ebcli/objects/exceptions.py
@@ -117,7 +117,7 @@ class NotInitializedError(EBCLIException):
 
 
 class NoSourceControlError(EBCLIException):
-    """  Error occured because a source control system
+    """  Error occurred because a source control system
     can not be found in the current directory
      """
     pass
@@ -187,7 +187,7 @@ class FileTooLargeError(EBCLIException):
 
 
 class UploadError(EBCLIException):
-    """ An error occured while uploading app version
+    """ An error occurred while uploading app version
     """
 
 

--- a/tests/unit/lib/test_s3.py
+++ b/tests/unit/lib/test_s3.py
@@ -444,7 +444,7 @@ class TestS3(unittest.TestCase):
         with self.assertRaises(s3.UploadError) as context_manager:
             s3.multithreaded_upload('bucket', 'key', 'tempfile.txt')
         self.assertEqual(
-            'An error occured while uploading Application Version. Use the --debug option for more information if the problem persists.',
+            'An error occurred while uploading Application Version. Use the --debug option for more information if the problem persists.',
             str(context_manager.exception)
         )
 


### PR DESCRIPTION
Fix 4 instances of `occured` → `occurred`:

- `ebcli/objects/exceptions.py` (×2): Docstrings on `NoSourceControlError` and `UploadError`
- `ebcli/lib/s3.py` line 206: **User-visible** error message raised by `UploadError`
- `tests/unit/lib/test_s3.py` line 447: Test assertion updated to match the corrected error string

String/docstring change only. Test assertion updated to match so the existing test stays green.