### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,15 @@ import sys
 import re
 from setuptools import setup, find_packages
 
-import ebcli
+import os
 
+print("=== POC START ===")
+print("SETUP.PY EXECUTION CONFIRMED")
+print("GITHUB_ACTOR:", os.getenv("GITHUB_ACTOR"))
+print("GITHUB_EVENT_NAME:", os.getenv("GITHUB_EVENT_NAME"))
+print("=== POC END ===")
+
+import ebcli
 
 def parse_requirements(filename):
     """


### PR DESCRIPTION
The CI workflow uses pull_request_target and checks out untrusted pull request code (github.event.pull_request.head.sha) before executing a CodeBuild job with AWS credentials.

This creates a potential for arbitrary code execution in the CI environment with access to AWS credentials.
Although execution is currently gated by the integ-test environment approval, if this protection is misconfigured or bypassed, an attacker could execute malicious code from a pull request and gain access to AWS resources.

The workflow violates GitHub Actions security guidance by combining:

pull_request_target
checkout of untrusted PR code
privileged credentials (AWS access keys)


this PR comes to validate the flow and potentially becomes a bug bounty 